### PR TITLE
handle invalid tags

### DIFF
--- a/visitor.php
+++ b/visitor.php
@@ -72,6 +72,10 @@ return new class extends NodeVisitor {
         $additions = [];
 
         foreach ($params as $param) {
+            // might be instanceof \phpDocumentor\Reflection\DocBlock\Tags\invalidTag if the param is invalid
+            if(!($param instanceof Param)) {
+                continue;
+            }
             $addition = $this->getAdditionFromParam($param);
 
             if ($addition !== null) {
@@ -79,7 +83,8 @@ return new class extends NodeVisitor {
             }
         }
 
-        if ($returns) {
+        // might be instanceof \phpDocumentor\Reflection\DocBlock\Tags\invalidTag if the return is invalid
+        if (isset($returns[0]) && $returns[0] instanceof Return_) {
             $addition = $this->getAdditionFromReturn($returns[0]);
 
             if ($addition !== null) {


### PR DESCRIPTION
Avoids notices and the generator to fail silently, if invalid tags (param, return) are encountered. Instead, this PR will just ignore invalidTags to ensure stubs are correctly created in these cases too.

Generally not a big issue in WordPress, but may happen.
Huge issue though, when using this visitor for WordPress plugins, which have bad QA (even from woocommerce.com)