### PR TITLE
Add additional parameter and return type information to stubs

### DIFF
--- a/additionalParams.php
+++ b/additionalParams.php
@@ -10,6 +10,8 @@ $httpReturnType = 'array{headers:Requests_Utility_CaseInsensitiveDictionary,body
  * @link https://github.com/phpstan/phpstan-src/blob/1.5.x/resources/functionMap.php
  */
 return [
+    'add_meta_box' => ['void', 'context'=>'"normal"|"side"|"advanced"', 'priority'=>'"high"|"core"|"default"|"low"'],
+    'remove_meta_box' => ['void', 'context'=>'"normal"|"side"|"advanced"'],
     'WP_Http::get' => [$httpReturnType],
     'WP_Http::head' => [$httpReturnType],
     'WP_Http::post' => [$httpReturnType],

--- a/additionalParams.php
+++ b/additionalParams.php
@@ -14,6 +14,7 @@ return [
     'WP_Http::head' => [$httpReturnType],
     'WP_Http::post' => [$httpReturnType],
     'WP_Http::request' => [$httpReturnType],
+    'WP_List_Table::bulk_actions' => ['void', 'which'=>'"top"|"bottom"'],
     'WP_List_Table::display_tablenav' => ['void', 'which'=>'"top"|"bottom"'],
     'WP_List_Table::pagination' => ['void', 'which'=>'"top"|"bottom"'],
     'wp_remote_get' => [$httpReturnType],

--- a/additionalParams.php
+++ b/additionalParams.php
@@ -10,6 +10,12 @@ $httpReturnType = 'array{headers:Requests_Utility_CaseInsensitiveDictionary,body
  * @link https://github.com/phpstan/phpstan-src/blob/1.5.x/resources/functionMap.php
  */
 return [
+    'WP_Http::get' => [$httpReturnType],
+    'WP_Http::head' => [$httpReturnType],
+    'WP_Http::post' => [$httpReturnType],
+    'WP_Http::request' => [$httpReturnType],
+    'WP_List_Table::display_tablenav' => ['void', 'which'=>'"top"|"bottom"'],
+    'WP_List_Table::pagination' => ['void', 'which'=>'"top"|"bottom"'],
     'wp_remote_get' => [$httpReturnType],
     'wp_remote_head' => [$httpReturnType],
     'wp_remote_post' => [$httpReturnType],
@@ -18,10 +24,4 @@ return [
     'wp_safe_remote_head' => [$httpReturnType],
     'wp_safe_remote_post' => [$httpReturnType],
     'wp_safe_remote_request' => [$httpReturnType],
-    'WP_Http::get' => [$httpReturnType],
-    'WP_Http::head' => [$httpReturnType],
-    'WP_Http::post' => [$httpReturnType],
-    'WP_Http::request' => [$httpReturnType],
-    'WP_List_Table::display_tablenav' => ['void', 'which'=>'"top"|"bottom"'],
-    'WP_List_Table::pagination' => ['void', 'which'=>'"top"|"bottom"'],
 ];

--- a/additionalParams.php
+++ b/additionalParams.php
@@ -2,6 +2,13 @@
 
 $httpReturnType = 'array{headers:Requests_Utility_CaseInsensitiveDictionary,body:string,response:array{code:int,message:string},cookies:array<int,WP_HTTP_Cookie>,filename:string|null,http_response:WP_HTTP_Requests_Response}|WP_Error';
 
+/**
+ * This array is in the same format as the stubs array in PHPStan:
+ *
+ * '<function_name>' => ['<return_type>, '<arg_name>'=>'<arg_type>']
+ *
+ * @link https://github.com/phpstan/phpstan-src/blob/1.5.x/resources/functionMap.php
+ */
 return [
     'wp_remote_get' => [$httpReturnType],
     'wp_remote_head' => [$httpReturnType],

--- a/additionalParams.php
+++ b/additionalParams.php
@@ -11,4 +11,8 @@ return [
     'wp_safe_remote_head' => [$httpReturnType],
     'wp_safe_remote_post' => [$httpReturnType],
     'wp_safe_remote_request' => [$httpReturnType],
+    'WP_Http::get' => [$httpReturnType],
+    'WP_Http::head' => [$httpReturnType],
+    'WP_Http::post' => [$httpReturnType],
+    'WP_Http::request' => [$httpReturnType],
 ];

--- a/additionalParams.php
+++ b/additionalParams.php
@@ -7,4 +7,8 @@ return [
     'wp_remote_head' => [$httpReturnType],
     'wp_remote_post' => [$httpReturnType],
     'wp_remote_request' => [$httpReturnType],
+    'wp_safe_remote_get' => [$httpReturnType],
+    'wp_safe_remote_head' => [$httpReturnType],
+    'wp_safe_remote_post' => [$httpReturnType],
+    'wp_safe_remote_request' => [$httpReturnType],
 ];

--- a/additionalParams.php
+++ b/additionalParams.php
@@ -3,8 +3,8 @@
 $httpReturnType = 'array{headers:Requests_Utility_CaseInsensitiveDictionary,body:string,response:array{code:int,message:string},cookies:array<int,WP_HTTP_Cookie>,filename:string|null,http_response:WP_HTTP_Requests_Response}|WP_Error';
 
 return [
-    'wp_remote_get' => [$httpReturnType, 'url'=>'string', 'args'=>'array'],
-    'wp_remote_head' => [$httpReturnType, 'url'=>'string', 'args'=>'array'],
-    'wp_remote_post' => [$httpReturnType, 'url'=>'string', 'args'=>'array'],
-    'wp_remote_request' => [$httpReturnType, 'url'=>'string', 'args'=>'array'],
+    'wp_remote_get' => [$httpReturnType],
+    'wp_remote_head' => [$httpReturnType],
+    'wp_remote_post' => [$httpReturnType],
+    'wp_remote_request' => [$httpReturnType],
 ];

--- a/additionalParams.php
+++ b/additionalParams.php
@@ -1,6 +1,6 @@
 <?php
 
-$httpReturnType = 'array{headers:array,body:string,response:array{code:int,message:string},cookies:WP_HTTP_Cookie[],filename:string|null}|WP_Error';
+$httpReturnType = 'array{headers:Requests_Utility_CaseInsensitiveDictionary,body:string,response:array{code:int,message:string},cookies:array<int,WP_HTTP_Cookie>,filename:string|null,http_response:WP_HTTP_Requests_Response}|WP_Error';
 
 return [
     'wp_remote_get' => [$httpReturnType, 'url'=>'string', 'args'=>'array'],

--- a/additionalParams.php
+++ b/additionalParams.php
@@ -1,0 +1,10 @@
+<?php
+
+$httpReturnType = 'array{headers:array,body:string,response:array{code:int,message:string},cookies:WP_HTTP_Cookie[],filename:string|null}|WP_Error';
+
+return [
+    'wp_remote_get' => [$httpReturnType, 'url'=>'string', 'args'=>'array'],
+    'wp_remote_head' => [$httpReturnType, 'url'=>'string', 'args'=>'array'],
+    'wp_remote_post' => [$httpReturnType, 'url'=>'string', 'args'=>'array'],
+    'wp_remote_request' => [$httpReturnType, 'url'=>'string', 'args'=>'array'],
+];

--- a/additionalParams.php
+++ b/additionalParams.php
@@ -15,4 +15,6 @@ return [
     'WP_Http::head' => [$httpReturnType],
     'WP_Http::post' => [$httpReturnType],
     'WP_Http::request' => [$httpReturnType],
+    'WP_List_Table::display_tablenav' => ['void', 'which'=>'"top"|"bottom"'],
+    'WP_List_Table::pagination' => ['void', 'which'=>'"top"|"bottom"'],
 ];

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "php": "~7.3 || ~8.0",
         "nikic/php-parser": "< 4.12.0",
-        "php-stubs/generator": "^0.8.0",
+        "php-stubs/generator": "dev-master",
         "phpdocumentor/reflection-docblock": "^5.3",
         "phpstan/phpstan": "^1.2"
     },

--- a/functionMap.php
+++ b/functionMap.php
@@ -3,7 +3,7 @@
 $httpReturnType = 'array{headers:Requests_Utility_CaseInsensitiveDictionary,body:string,response:array{code:int,message:string},cookies:array<int,WP_HTTP_Cookie>,filename:string|null,http_response:WP_HTTP_Requests_Response}|WP_Error';
 
 /**
- * This array is in the same format as the stubs array in PHPStan:
+ * This array is in the same format as the function map array in PHPStan:
  *
  * '<function_name>' => ['<return_type>, '<arg_name>'=>'<arg_type>']
  *

--- a/functionMap.php
+++ b/functionMap.php
@@ -1,6 +1,6 @@
 <?php
 
-$httpReturnType = 'array{headers:Requests_Utility_CaseInsensitiveDictionary,body:string,response:array{code:int,message:string},cookies:array<int,WP_HTTP_Cookie>,filename:string|null,http_response:WP_HTTP_Requests_Response}|WP_Error';
+$httpReturnType = 'array{headers: \Requests_Utility_CaseInsensitiveDictionary, body: string, response: array{code: int,message: string}, cookies: array<int, \WP_HTTP_Cookie>, filename: string|null, http_response: \WP_HTTP_Requests_Response}|\WP_Error';
 
 /**
  * This array is in the same format as the function map array in PHPStan:

--- a/visitor.php
+++ b/visitor.php
@@ -49,6 +49,18 @@ return new class extends NodeVisitor {
         }
 
         $this->currentSymbolName = $node->name->name;
+
+        if ($node instanceof ClassMethod) {
+            /** @var \PhpParser\Node\Stmt\Class_ $parent */
+            $parent = $this->stack[count($this->stack) - 2];
+
+            $this->currentSymbolName = sprintf(
+                '%1$s::%2$s',
+                $parent->name->name,
+                $node->name->name
+            );
+        }
+
         $newDocComment = $this->addArrayHashNotation($docComment);
 
         if ($newDocComment !== null) {

--- a/visitor.php
+++ b/visitor.php
@@ -20,9 +20,9 @@ return new class extends NodeVisitor {
     private $docBlockFactory;
 
     /**
-     * @var array<string,array<int|string,string>>
+     * @var ?array<string,array<int|string,string>>
      */
-    private $functionMap;
+    private $functionMap = null;
 
     /**
      * @var string
@@ -54,11 +54,13 @@ return new class extends NodeVisitor {
             /** @var \PhpParser\Node\Stmt\Class_ $parent */
             $parent = $this->stack[count($this->stack) - 2];
 
-            $this->currentSymbolName = sprintf(
-                '%1$s::%2$s',
-                $parent->name->name,
-                $node->name->name
-            );
+            if (isset($parent->name)) {
+                $this->currentSymbolName = sprintf(
+                    '%1$s::%2$s',
+                    $parent->name->name,
+                    $node->name->name
+                );
+            }
         }
 
         $newDocComment = $this->addArrayHashNotation($docComment);

--- a/visitor.php
+++ b/visitor.php
@@ -22,7 +22,7 @@ return new class extends NodeVisitor {
     /**
      * @var array<string,array<int|string,string>>
      */
-    private $additionalParams;
+    private $functionMap;
 
     /**
      * @var string
@@ -137,23 +137,23 @@ return new class extends NodeVisitor {
 
     private function addAdditionalParams(Doc $docComment): ?Doc
     {
-        if (! isset($this->additionalParams)) {
-            $this->additionalParams = require __DIR__ . '/additionalParams.php';
+        if (! isset($this->functionMap)) {
+            $this->functionMap = require __DIR__ . '/functionMap.php';
         }
 
-        if (! isset($this->additionalParams[$this->currentSymbolName])) {
+        if (! isset($this->functionMap[$this->currentSymbolName])) {
             return null;
         }
 
-        $params = $this->additionalParams[$this->currentSymbolName];
-        $returnType = array_shift($params);
+        $parameters = $this->functionMap[$this->currentSymbolName];
+        $returnType = array_shift($parameters);
         $additions = [];
 
-        foreach ($params as $param => $paramType) {
+        foreach ($parameters as $paramName => $paramType) {
             $additions[] = sprintf(
                 '@phpstan-param %s $%s',
                 $paramType,
-                $param
+                $paramName
             );
         }
 


### PR DESCRIPTION
This introduces some more functionality to the node visitor which appends PHPStan-specific `@phpstan-param` and `@phpstan-return` tags to the docblock for given functions and methods.

This allows for us to increase the specificity of return values and parameters for PHPStan usage specifically.

The `functionMap.php` file is formatted in a similar manner to the same file in PHPStan itself. Any number of functions and methods can be added in order to override the return type and zero or more of its parameter types.

The resulting changes for the functions and methods I've added so far can be seen in `wordpress-stubs.php`.

@szepeviktor What do you think?

This relies on https://github.com/php-stubs/generator/pull/13