### PR TITLE
Generate stubs for WordPress 6.0.1

### DIFF
--- a/source/composer.json
+++ b/source/composer.json
@@ -7,7 +7,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "ext-sodium": "*",
-        "johnpbloch/wordpress": "6.0.0"
+        "johnpbloch/wordpress": "6.0.1"
     },
     "minimum-stability": "stable",
     "config": {


### PR DESCRIPTION
I thought that's the least I could do, since I was kind of annoying in the literal-string issue ;)

but basically nothing changed. not sure how you handle those, feel free  to close if you prefer no update. A new release afterwards would help getting the literal-string fix though I guess hehe