### PR TITLE
Ensure the arguments for cron events are numerically indexed

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -1,7 +1,7 @@
 <?php
 
 $httpReturnType = 'array{headers: \Requests_Utility_CaseInsensitiveDictionary, body: string, response: array{code: int,message: string}, cookies: array<int, \WP_HTTP_Cookie>, filename: string|null, http_response: \WP_HTTP_Requests_Response}|\WP_Error';
-$cronArgsType = 'array<int, mixed>';
+$cronArgsType = 'list<mixed>';
 
 /**
  * This array is in the same format as the function map array in PHPStan:

--- a/functionMap.php
+++ b/functionMap.php
@@ -1,6 +1,7 @@
 <?php
 
 $httpReturnType = 'array{headers: \Requests_Utility_CaseInsensitiveDictionary, body: string, response: array{code: int,message: string}, cookies: array<int, \WP_HTTP_Cookie>, filename: string|null, http_response: \WP_HTTP_Requests_Response}|\WP_Error';
+$cronArgsType = 'array<int, mixed>';
 
 /**
  * This array is in the same format as the function map array in PHPStan:
@@ -20,6 +21,9 @@ return [
     'stripslashes_deep' => ['T', '@phpstan-template'=>'T', 'value'=>'T'],
     'urldecode_deep' => ['T', '@phpstan-template'=>'T', 'value'=>'T'],
     'urlencode_deep' => ['T', '@phpstan-template'=>'T', 'value'=>'T'],
+    'wp_clear_scheduled_hook' => ['int|false|WP_Error', 'args'=>$cronArgsType],
+    'wp_get_schedule' => ['string|false', 'args'=>$cronArgsType],
+    'wp_get_scheduled_event' => ['object|false', 'args'=>$cronArgsType],
     'WP_Http::get' => [$httpReturnType],
     'WP_Http::head' => [$httpReturnType],
     'WP_Http::post' => [$httpReturnType],
@@ -27,14 +31,19 @@ return [
     'WP_List_Table::bulk_actions' => ['void', 'which'=>'"top"|"bottom"'],
     'WP_List_Table::display_tablenav' => ['void', 'which'=>'"top"|"bottom"'],
     'WP_List_Table::pagination' => ['void', 'which'=>'"top"|"bottom"'],
+    'wp_next_scheduled' => ['int|false', 'args'=>$cronArgsType],
     'wp_remote_get' => [$httpReturnType],
     'wp_remote_head' => [$httpReturnType],
     'wp_remote_post' => [$httpReturnType],
     'wp_remote_request' => [$httpReturnType],
+    'wp_reschedule_event' => ['bool|WP_Error', 'args'=>$cronArgsType],
     'wp_safe_remote_get' => [$httpReturnType],
     'wp_safe_remote_head' => [$httpReturnType],
     'wp_safe_remote_post' => [$httpReturnType],
     'wp_safe_remote_request' => [$httpReturnType],
+    'wp_schedule_event' => ['bool|WP_Error', 'args'=>$cronArgsType],
+    'wp_schedule_single_event' => ['bool|WP_Error', 'args'=>$cronArgsType],
     'wp_slash' => ['T', '@phpstan-template'=>'T', 'value'=>'T'],
+    'wp_unschedule_event' => ['bool|WP_Error', 'args'=>$cronArgsType],
     'wp_unslash' => ['T', '@phpstan-template'=>'T', 'value'=>'T'],
 ];


### PR DESCRIPTION
The `$args` parameter for functions related to cron events should be a numerically indexed array. Using an associative array means you might be attempting to use the arguments incorrectly in your cron event callback.