### PR TITLE
Handle nested `@type` tags

### DIFF
--- a/visitor.php
+++ b/visitor.php
@@ -249,9 +249,14 @@ return new class extends NodeVisitor {
 
     private function getTypeNameFromType(Type $tagVariableType): ?string
     {
+        return $this->getTypeNameFromString($tagVariableType->__toString());
+    }
+
+    private function getTypeNameFromString(string $tagVariable): ?string
+    {
         // PHPStan dosn't support typed array shapes (`int[]{...}`) so replace
         // typed arrays such as `int[]` with `array`.
-        $tagVariableType = preg_replace('#[a-zA-Z0-9_]+\[\]#', 'array', $tagVariableType->__toString());
+        $tagVariableType = preg_replace('#[a-zA-Z0-9_]+\[\]#', 'array', $tagVariable);
 
         if ($tagVariableType === null) {
             return null;
@@ -332,7 +337,8 @@ return new class extends NodeVisitor {
                 $currentIdent = str_repeat(' ', (2 * $level));
                 $indent = str_repeat(' ', (2 * $nextLevel));
                 $type = sprintf(
-                    'array{%s%s%s}',
+                    '%s{%s%s%s}',
+                    $this->getTypeNameFromString($type),
                     "\n * {$indent}",
                     implode(",\n * {$indent}", $subTypes),
                     "\n * {$currentIdent}"

--- a/visitor.php
+++ b/visitor.php
@@ -249,7 +249,17 @@ return new class extends NodeVisitor {
 
     private function getTypeNameFromType(Type $tagVariableType): ?string
     {
-        return $this->getTypeNameFromString($tagVariableType->__toString());
+        $tagVariableType = $this->getTypeNameFromString($tagVariableType->__toString());
+
+        if ($tagVariableType === null) {
+            return null;
+        }
+
+        // It's common for an args parameter to accept a query var string or array with `string|array`.
+        // Remove the accepted string type for these so we get the strongest typing we can manage.
+        $tagVariableType = str_replace(['|string', 'string|'], '', $tagVariableType);
+
+        return $tagVariableType;
     }
 
     private function getTypeNameFromString(string $tagVariable): ?string
@@ -271,10 +281,6 @@ return new class extends NodeVisitor {
             // Move `array` to the end of union types so the appended array shape works.
             $tagVariableType = str_replace('array|', '', $tagVariableType) . '|array';
         }
-
-        // It's common for an args parameter to accept a query var string or array with `string|array`.
-        // Remove the accepted string type for these so we get the strongest typing we can manage.
-        $tagVariableType = str_replace(['|string', 'string|'], '', $tagVariableType);
 
         return $tagVariableType;
     }

--- a/visitor.php
+++ b/visitor.php
@@ -210,10 +210,6 @@ return new class extends NodeVisitor {
             return null;
         }
 
-        // It's common for an args parameter to accept a query var string or array with `string|array`.
-        // Remove the accepted string type for these so we get the strongest typing we can manage.
-        $tagVariableType = str_replace(['|string', 'string|'], '', $tagVariableType);
-
         return sprintf(
             " * @phpstan-param %1\$s{\n *   %2\$s,\n * } $%3\$s",
             $tagVariableType,
@@ -270,6 +266,10 @@ return new class extends NodeVisitor {
             // Move `array` to the end of union types so the appended array shape works.
             $tagVariableType = str_replace('array|', '', $tagVariableType) . '|array';
         }
+
+        // It's common for an args parameter to accept a query var string or array with `string|array`.
+        // Remove the accepted string type for these so we get the strongest typing we can manage.
+        $tagVariableType = str_replace(['|string', 'string|'], '', $tagVariableType);
 
         return $tagVariableType;
     }

--- a/visitor.php
+++ b/visitor.php
@@ -210,6 +210,10 @@ return new class extends NodeVisitor {
             return null;
         }
 
+        // It's common for an args parameter to accept a query var string or array with `string|array`.
+        // Remove the accepted string type for these so we get the strongest typing we can manage.
+        $tagVariableType = str_replace(['|string', 'string|'], '', $tagVariableType);
+
         return sprintf(
             " * @phpstan-param %1\$s{\n *   %2\$s,\n * } $%3\$s",
             $tagVariableType,
@@ -249,17 +253,7 @@ return new class extends NodeVisitor {
 
     private function getTypeNameFromType(Type $tagVariableType): ?string
     {
-        $tagVariableType = $this->getTypeNameFromString($tagVariableType->__toString());
-
-        if ($tagVariableType === null) {
-            return null;
-        }
-
-        // It's common for an args parameter to accept a query var string or array with `string|array`.
-        // Remove the accepted string type for these so we get the strongest typing we can manage.
-        $tagVariableType = str_replace(['|string', 'string|'], '', $tagVariableType);
-
-        return $tagVariableType;
+        return $this->getTypeNameFromString($tagVariableType->__toString());
     }
 
     private function getTypeNameFromString(string $tagVariable): ?string

--- a/visitor.php
+++ b/visitor.php
@@ -341,7 +341,7 @@ return new class extends NodeVisitor {
                     $this->getTypeNameFromString($type),
                     "\n * {$indent}",
                     implode(",\n * {$indent}", $subTypes),
-                    "\n * {$currentIdent}"
+                    ",\n * {$currentIdent}"
                 );
             }
 

--- a/visitor.php
+++ b/visitor.php
@@ -200,7 +200,7 @@ return new class extends NodeVisitor {
 
         $elements = $this->getElementsFromDescription($tagDescription, true);
 
-        if ($elements === null) {
+        if (count($elements) === 0) {
             return null;
         }
 
@@ -230,7 +230,7 @@ return new class extends NodeVisitor {
 
         $elements = $this->getElementsFromDescription($tagDescription, false);
 
-        if ($elements === null) {
+        if (count($elements) === 0) {
             return null;
         }
 
@@ -280,32 +280,32 @@ return new class extends NodeVisitor {
     }
 
     /**
-     * @return ?string[]
+     * @return string[]
      */
-    private function getElementsFromDescription(Description $tagDescription, bool $optional): ?array
+    private function getElementsFromDescription(Description $tagDescription, bool $optional): array
     {
         $text = $tagDescription->__toString();
 
         // Skip if the description doesn't contain at least one correctly
         // formatted `@type`, which indicates an array hash.
         if (strpos($text, '    @type ') === false) {
-            return null;
+            return [];
         }
 
         return $this->getTypesAtLevel($text, $optional, 1);
     }
 
     /**
-     * @return ?string[]
+     * @return string[]
      */
-    private function getTypesAtLevel(string $text, bool $optional, int $level): ?array
+    private function getTypesAtLevel(string $text, bool $optional, int $level): array
     {
         // Populate `$types` with the value of each top level `@type`.
         $spaces = str_repeat(' ', ($level * 4));
         $types = preg_split("/\R+{$spaces}@type /", $text);
 
         if ($types === false) {
-            return null;
+            return [];
         }
 
         unset($types[0]);
@@ -315,25 +315,25 @@ return new class extends NodeVisitor {
             $parts = preg_split('#\s+#', trim($typeTag));
 
             if ($parts === false || count($parts) < 2) {
-                return null;
+                return [];
             }
 
             list($type, $name) = $parts;
 
             // Bail out completely if any element doesn't have a static key.
             if (strpos($name, '...$') !== false) {
-                return null;
+                return [];
             }
 
             // Bail out completely if the name of any element is invalid.
             if (strpos($name, '$') !== 0) {
-                return null;
+                return [];
             }
 
             $nextLevel = $level + 1;
             $subTypes = $this->getTypesAtLevel($typeTag, $optional, $nextLevel);
 
-            if (! empty($subTypes)) {
+            if (count($subTypes) > 0) {
                 $currentIdent = str_repeat(' ', (2 * $level));
                 $indent = str_repeat(' ', (2 * $nextLevel));
                 $type = sprintf(


### PR DESCRIPTION
This adds recursive functionality to the `@type` notation handling, so second- and third- level array shapes are supported.