### PR TITLE
Tag code refactoring

### DIFF
--- a/visitor.php
+++ b/visitor.php
@@ -29,7 +29,7 @@ final class WordPressTag {
     public $name = null;
 
     /**
-     * @var WordPressParam[]
+     * @var WordPressArg[]
      */
     public $children = [];
 
@@ -58,7 +58,7 @@ final class WordPressTag {
     }
 }
 
-final class WordPressParam {
+final class WordPressArg {
     /**
      * @var string
      */
@@ -75,7 +75,7 @@ final class WordPressParam {
     public $name = null;
 
     /**
-     * @var WordPressParam[]
+     * @var WordPressArg[]
      */
     public $children = [];
 
@@ -387,7 +387,7 @@ return new class extends NodeVisitor {
     }
 
     /**
-     * @return WordPressParam[]
+     * @return WordPressArg[]
      */
     private function getElementsFromDescription(Description $tagDescription, bool $optional): array
     {
@@ -403,7 +403,7 @@ return new class extends NodeVisitor {
     }
 
     /**
-     * @return WordPressParam[]
+     * @return WordPressArg[]
      */
     private function getTypesAtLevel(string $text, bool $optional, int $level): array
     {
@@ -437,7 +437,7 @@ return new class extends NodeVisitor {
                 return [];
             }
 
-            $param = new WordPressParam();
+            $param = new WordPressArg();
             $param->type = $type;
             $param->optional = $optional;
             $param->name = substr($name, 1);

--- a/visitor.php
+++ b/visitor.php
@@ -319,13 +319,13 @@ return new class extends NodeVisitor {
         // Remove the accepted string type for these so we get the strongest typing we can manage.
         $tagVariableType = str_replace(['|string', 'string|'], '', $tagVariableType);
 
-        $param = new WordPressTag();
-        $param->tag = '@phpstan-param';
-        $param->type = $tagVariableType;
-        $param->name = $tagVariableName;
-        $param->children = $elements;
+        $tag = new WordPressTag();
+        $tag->tag = '@phpstan-param';
+        $tag->type = $tagVariableType;
+        $tag->name = $tagVariableName;
+        $tag->children = $elements;
 
-        return $param;
+        return $tag;
     }
 
     private function getAdditionFromReturn(Return_ $tag): ?WordPressTag
@@ -350,12 +350,12 @@ return new class extends NodeVisitor {
             return null;
         }
 
-        $param = new WordPressTag();
-        $param->tag = '@phpstan-return';
-        $param->type = $tagVariableType;
-        $param->children = $elements;
+        $tag = new WordPressTag();
+        $tag->tag = '@phpstan-return';
+        $tag->type = $tagVariableType;
+        $tag->children = $elements;
 
-        return $param;
+        return $tag;
     }
 
     private function getTypeNameFromType(Type $tagVariableType): ?string
@@ -437,10 +437,10 @@ return new class extends NodeVisitor {
                 return [];
             }
 
-            $param = new WordPressArg();
-            $param->type = $type;
-            $param->optional = $optional;
-            $param->name = substr($name, 1);
+            $arg = new WordPressArg();
+            $arg->type = $type;
+            $arg->optional = $optional;
+            $arg->name = substr($name, 1);
 
             $nextLevel = $level + 1;
             $subTypes = $this->getTypesAtLevel($typeTag, $optional, $nextLevel);
@@ -449,12 +449,12 @@ return new class extends NodeVisitor {
                 $type = $this->getTypeNameFromString($type);
 
                 if ($type !== null) {
-                    $param->type = $type;
+                    $arg->type = $type;
                 }
-                $param->children = $subTypes;
+                $arg->children = $subTypes;
             }
 
-            $elements[] = $param;
+            $elements[] = $arg;
         }
 
         return $elements;

--- a/visitor.php
+++ b/visitor.php
@@ -12,7 +12,8 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use StubsGenerator\NodeVisitor;
 
-final class WordPressTag {
+final class WordPressTag
+{
     /**
      * @var string
      */
@@ -36,7 +37,8 @@ final class WordPressTag {
     /**
      * @return string[]
      */
-    public function format(): array {
+    public function format(): array
+    {
         $strings = [];
 
         $strings[] = sprintf(
@@ -58,7 +60,8 @@ final class WordPressTag {
     }
 }
 
-final class WordPressArg {
+final class WordPressArg
+{
     /**
      * @var string
      */
@@ -82,7 +85,8 @@ final class WordPressArg {
     /**
      * @return string[]
      */
-    public function format(int $level = 1): array {
+    public function format(int $level = 1): array
+    {
         $strings = [];
         $padding = str_repeat(' ', ($level * 2));
 


### PR DESCRIPTION
This refactors the code added in #44 so it's more structured. The data about tags and parameters only gets formatted to strings just before it gets output.

When running `./generate.sh` the output to `wordpress-stubs.php` is identical.

This change enables some more processing of parameters that I'd like to do.