### PR TITLE
Support for dynamic keys, `@var`s, and optional elements

### DIFF
--- a/visitor.php
+++ b/visitor.php
@@ -596,7 +596,7 @@ return new class extends NodeVisitor {
             if (is_numeric($nameTrimmed)) {
                 $optionalArg = false;
             } elseif ($optional && ($level > 1)) {
-                $optionalArg = (isset($parts[2]) && stripos($parts[2], 'optional') !== false);
+                $optionalArg = isset($parts[2]) && self::isOptional($parts[2]);
             }
 
             if (strpos($name, '...$') !== false) {
@@ -628,5 +628,14 @@ return new class extends NodeVisitor {
         }
 
         return $elements;
+    }
+
+    private static function isOptional(string $description): bool
+    {
+        return (stripos($description, 'Optional') !== false)
+            || (stripos($description, 'Default ') !== false)
+            || (stripos($description, 'Default: ') !== false)
+            || (stripos($description, 'Defaults to ') !== false)
+        ;
     }
 };

--- a/visitor.php
+++ b/visitor.php
@@ -253,8 +253,20 @@ return new class extends NodeVisitor {
         }
 
         $additions = array_map( function(WordPressTag $param): string {
-            return " * " . implode("\n * ", $param->format());
+            $lines = $param->format();
+
+            if (count($lines) === 0) {
+                return '';
+            }
+
+            return " * " . implode("\n * ", $lines);
         }, $additions);
+
+        $additions = array_filter($additions);
+
+        if (count($additions) === 0) {
+            return null;
+        }
 
         $newDocComment = sprintf(
             "%s\n%s\n */",

--- a/visitor.php
+++ b/visitor.php
@@ -535,7 +535,7 @@ return new class extends NodeVisitor {
         $elements = [];
 
         foreach ($types as $typeTag) {
-            $parts = preg_split('#\s+#', trim($typeTag));
+            $parts = preg_split('#\s+#', trim($typeTag), 3);
 
             if ($parts === false || count($parts) < 2) {
                 return [];
@@ -543,17 +543,26 @@ return new class extends NodeVisitor {
 
             list($type, $name) = $parts;
 
+            $optionalArg = $optional;
+            $nameTrimmed = ltrim($name, '$');
+
+            if (is_numeric($nameTrimmed)) {
+                $optionalArg = false;
+            } elseif ($optional && ($level > 1)) {
+                $optionalArg = (isset($parts[2]) && stripos($parts[2], 'optional') !== false);
+            }
+
             if (strpos($name, '...$') !== false) {
                 $name = null;
             } elseif (strpos($name, '$') !== 0) {
                 return [];
             } else {
-                $name = ltrim($name, '$');
+                $name = $nameTrimmed;
             }
 
             $arg = new WordPressArg();
             $arg->type = $type;
-            $arg->optional = $optional;
+            $arg->optional = $optionalArg;
             $arg->name = $name;
 
             $nextLevel = $level + 1;

--- a/visitor.php
+++ b/visitor.php
@@ -12,7 +12,26 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use StubsGenerator\NodeVisitor;
 
-final class WordPressTag
+abstract class WithChildren
+{
+    /**
+     * @var WordPressArg[]
+     */
+    public $children = [];
+
+    public function isArrayShape(): bool
+    {
+        foreach ($this->children as $child) {
+            if ($child->name === null) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+final class WordPressTag extends WithChildren
 {
     /**
      * @var string
@@ -28,11 +47,6 @@ final class WordPressTag
      * @var ?string
      */
     public $name = null;
-
-    /**
-     * @var WordPressArg[]
-     */
-    public $children = [];
 
     /**
      * @return string[]
@@ -60,7 +74,7 @@ final class WordPressTag
     }
 }
 
-final class WordPressArg
+final class WordPressArg extends WithChildren
 {
     /**
      * @var string
@@ -76,11 +90,6 @@ final class WordPressArg
      * @var ?string
      */
     public $name = null;
-
-    /**
-     * @var WordPressArg[]
-     */
-    public $children = [];
 
     /**
      * @return string[]

--- a/visitor.php
+++ b/visitor.php
@@ -61,8 +61,14 @@ final class WordPressTag extends WithChildren
             $this->type
         );
 
+        $level = 1;
+
+        if (! $this->isArrayShape()) {
+            $level = 0;
+        }
+
         foreach ($this->children as $child) {
-            $strings = array_merge($strings, $child->format());
+            $strings = array_merge($strings, $child->format($level));
         }
 
         $strings[] = sprintf(
@@ -440,20 +446,18 @@ return new class extends NodeVisitor {
 
             list($type, $name) = $parts;
 
-            // Bail out completely if any element doesn't have a static key.
             if (strpos($name, '...$') !== false) {
+                $name = null;
+            } elseif (strpos($name, '$') !== 0) {
                 return [];
-            }
-
-            // Bail out completely if the name of any element is invalid.
-            if (strpos($name, '$') !== 0) {
-                return [];
+            } else {
+                $name = ltrim($name, '$');
             }
 
             $arg = new WordPressArg();
             $arg->type = $type;
             $arg->optional = $optional;
-            $arg->name = substr($name, 1);
+            $arg->name = $name;
 
             $nextLevel = $level + 1;
             $subTypes = $this->getTypesAtLevel($typeTag, $optional, $nextLevel);


### PR DESCRIPTION
This PR introduces three improvements:

* Handling for non-static array keys in `@type` tags (fixes #47)
* Handling for array shapes in `@var` tags
* More accurate handling for optional elements in array shapes