### PR TITLE
Merge arguments when an inheriting function specifies some arguments

### DIFF
--- a/visitor.php
+++ b/visitor.php
@@ -144,7 +144,6 @@ final class WordPressTag extends WithChildren
             );
         }
 
-
         return $strings;
     }
 }
@@ -499,18 +498,33 @@ return new class extends NodeVisitor {
      */
     private function discoverInheritedArgs(DocBlock $docblock, array $additions): array
     {
-        foreach ($additions as $add) {
-            if ($add->tag === '@phpstan-param') {
-                // We can't yet handle merging args.
-                return $additions;
-            }
-        }
-
         /** @var Param[] $params */
         $params = $docblock->getTagsByName('param');
 
         foreach ($params as $param) {
-            $additions = array_merge($additions, $this->getInheritedTagsForParam($param));
+            $inherited = $this->getInheritedTagsForParam($param);
+
+            if (count($inherited) === 0) {
+                continue;
+            }
+
+            foreach ($additions as $addition) {
+                if ($addition->tag !== '@phpstan-param') {
+                    continue;
+                }
+
+                foreach ($inherited as $inherit) {
+                    if ($addition->name !== $inherit->name) {
+                        continue;
+                    }
+
+                    $addition->children = array_merge($addition->children, $inherit->children);
+                    continue 3;
+                }
+
+            }
+
+            $additions = array_merge($additions, $inherited);
         }
 
         return $additions;

--- a/visitor.php
+++ b/visitor.php
@@ -501,6 +501,10 @@ return new class extends NodeVisitor {
         /** @var Param[] $params */
         $params = $docblock->getTagsByName('param');
 
+        $phpStanParams = array_filter($additions, function(WordPressTag $addition): bool {
+            return $addition->tag === '@phpstan-param';
+        });
+
         foreach ($params as $param) {
             $inherited = $this->getInheritedTagsForParam($param);
 
@@ -508,11 +512,7 @@ return new class extends NodeVisitor {
                 continue;
             }
 
-            foreach ($additions as $addition) {
-                if ($addition->tag !== '@phpstan-param') {
-                    continue;
-                }
-
+            foreach ($phpStanParams as $addition) {
                 foreach ($inherited as $inherit) {
                     if ($addition->name !== $inherit->name) {
                         continue;
@@ -521,7 +521,6 @@ return new class extends NodeVisitor {
                     $addition->children = array_merge($addition->children, $inherit->children);
                     continue 3;
                 }
-
             }
 
             $additions = array_merge($additions, $inherited);


### PR DESCRIPTION
This handles functions such as `wp_tag_cloud()` which partially specifies some args and then also inherits its args from `wp_generate_tag_cloud()`.

PHPStan supports duplicate keys in an array shape definition by merging their types if they differ, for example: https://phpstan.org/r/55c06b70-ff98-406d-beca-1d6b32065fe5. This means we can safely merge the two shapes without needing to remove duplicate keys. Neato.

## Todo

* [ ] Remove all these nested loops