### PR TITLE
Add extra php attribute to methods for 8+ Fixes #52

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -58,12 +58,12 @@ for METHOD in "${REQUESTS_V1_METHODS[@]}"; do
     echo "${METHOD} is defined on line ${LINE}."
 
     # Check the previous line forr ReturnTypeWillChange attribute.
-    if sed -e "$((LINE - 1))q;d" "${FILE}" | grep -q -F '#[ReturnTypeWillChange]'; then
+    if sed -e "$((LINE - 1)) !d" "${FILE}" | grep -q -F '#[ReturnTypeWillChange]'; then
         continue
     fi
 
     # Grab leading whitespace on the current line so we can indent ReturnTypeWillChange correctly.
-    LEADING_WHITESPACES="$(sed -e "${LINE}q;d" -e 's#\([[:space:]]\+\)\(.*\)#\1#' "${FILE}")"
+    LEADING_WHITESPACES="$(sed -e "${LINE} !d;s#^\\(\\s\\+\\).*$#\\1#" "${FILE}")"
     # Insert the ReturnTypeWillChange attribute.
-    sed -i -e "${LINE}i\\" -e "${LEADING_WHITESPACES}#[ReturnTypeWillChange]" "${FILE}"
+    sed -i -e "${LINE} i\\" -e "${LEADING_WHITESPACES}#[ReturnTypeWillChange]" "${FILE}"
 done

--- a/generate.sh
+++ b/generate.sh
@@ -63,7 +63,7 @@ for METHOD in "${REQUESTS_V1_METHODS[@]}"; do
     fi
 
     # Grab leading whitespace on the current line so we can indent ReturnTypeWillChange correctly.
-    LEADING_WHITESPACES="$(sed -e "${LINE} !d;s#^\\(\\s\\+\\).*$#\\1#" "${FILE}")"
+    LEADING_WHITESPACES="$(sed -e "${LINE} !d;s#^\\(\\s\\+\\).*\$#\\1#" "${FILE}")"
     # Insert the ReturnTypeWillChange attribute.
     sed -i -e "${LINE} i\\" -e "${LEADING_WHITESPACES}#[ReturnTypeWillChange]" "${FILE}"
 done

--- a/generate.sh
+++ b/generate.sh
@@ -35,3 +35,36 @@ if grep -qFx 'namespace {' "$FILE"; then
 else
     printf '\n/**\n * WordPress database abstraction object.\n * @var wpdb\n */\n$wpdb = \\null;\n' >>"$FILE"
 fi
+
+# These are function that need a extra attribute to prevent php8+ notices.
+declare -a PHP_FUNCTIONS=(
+    'Requests_Utility_FilteredIterator::unserialize'
+    'Requests_Utility_FilteredIterator::__unserialize'
+    'Requests_Utility_FilteredIterator::current'
+    'Requests_Cookie_Jar::offsetExists'
+    'Requests_Cookie_Jar::offsetGet'
+    'Requests_Cookie_Jar::offsetSet'
+    'Requests_Cookie_Jar::offsetUnset'
+    'Requests_Cookie_Jar::getIterator'
+    'Requests_Utility_CaseInsensitiveDictionary::offsetExists'
+    'Requests_Utility_CaseInsensitiveDictionary::offsetGet'
+    'Requests_Utility_CaseInsensitiveDictionary::offsetSet'
+    'Requests_Utility_CaseInsensitiveDictionary::offsetUnset'
+    'Requests_Utility_CaseInsensitiveDictionary::getIterator'
+)
+for PHP_FUNCTION in "${PHP_FUNCTIONS[@]}"; do
+    # Get the line where the method is defined.
+    LINE=$(php -r "include 'wordpress-stubs.php'; print (new ReflectionMethod('${PHP_FUNCTION}'))->getStartLine();")
+    echo "${PHP_FUNCTION} is defined on line ${LINE}"
+
+    # Check the line above for #[ReturnTypeWillChange]
+    if [[ $(sed "$((${LINE}-1))q;d" ${FILE}) == *'#[ReturnTypeWillChange]' ]]; then
+        echo "${PHP_FUNCTION} already has #[ReturnTypeWillChange]"
+        continue # Already there.
+    fi
+
+    # Grab the current leading whitespace so we can keep the #[ReturnTypeWillChange] indented correctly.
+    LEADING_WHITESPACE="$(sed "${LINE}q;d" ${FILE} | sed "s#\([[:space:]]\+\)\(.*\)#\1#")"
+    # Insert the #[ReturnTypeWillChange]
+    sed -e "${LINE}i\\" -e "${LEADING_WHITESPACE}#[ReturnTypeWillChange]" -i ${FILE}
+done


### PR DESCRIPTION
These functions are giving notices on php 8+.
The fix is adding a extra php attribute to the methods: #[ReturnTypeWillChange]

There where a couple of difficulties. So I took a different approach.

1. Just using `sed` for a method couldn't target the function of a specific class. So I used php reflection.
2. I wanted to prevent adding multiple `#[ReturnTypeWillChange]` So I check if it's not already present.
So when https://github.com/WordPress/Requests/pull/505 lands, this won't create duplicates.
3. I wanted to make sure the indenting was correct for the attribute.

Overall fun thing to include.