### PR TITLE
Add `@phpstan-assert` to `is_wp_error`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "nikic/php-parser": "< 4.12.0",
         "php-stubs/generator": "^0.8.3",
         "phpdocumentor/reflection-docblock": "^5.3",
-        "phpstan/phpstan": "^1.2"
+        "phpstan/phpstan": "^1.9"
     },
     "suggest": {
         "paragonie/sodium_compat": "Pure PHP implementation of libsodium",

--- a/functionMap.php
+++ b/functionMap.php
@@ -65,4 +65,5 @@ return [
     'WP_Block_List::offsetGet' => ['WP_Block|null', 'offset'=>'int'],
     'WP_Block_List::offsetSet' => ['void', 'offset'=>'int|null'],
     'WP_Block_List::offsetUnset' => ['void', 'offset'=>'int'],
+    'is_wp_error' => ['bool', '@phpstan-assert-if-true'=>'\WP_Error $thing']
 ];


### PR DESCRIPTION
See https://github.com/szepeviktor/phpstan-wordpress/issues/168 and https://phpstan.org/writing-php-code/narrowing-types#custom-type-checking-functions-and-methods