### PR TITLE
Add TypeInferenceTest for `current_time()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.phpunit.result.cache
 /vendor/
 /composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,5 +51,5 @@ script:
   - "git diff --exit-code"
   # Execute stubs
   - "php -f wordpress-stubs.php"
-  # Analyse our code
-  - "composer exec -- phpstan"
+  # Run tests
+  - "composer test"

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,18 @@
         "nikic/php-parser": "< 4.12.0",
         "php-stubs/generator": "^0.8.3",
         "phpdocumentor/reflection-docblock": "^5.3",
-        "phpstan/phpstan": "^1.9"
+        "phpstan/phpstan": "^1.9",
+        "phpunit/phpunit": "^9.5"
     },
     "suggest": {
         "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
         "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
         "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+    },
+    "autoload-dev": {
+        "classmap": [
+            "tests/"
+        ]
     },
     "minimum-stability": "stable",
     "config": {
@@ -29,7 +35,13 @@
     "scripts": {
         "post-install-cmd": "@composer --working-dir=source/ update --no-interaction",
         "post-update-cmd": "@composer --working-dir=source/ update --no-interaction",
-        "cleanup": "git status --short --ignored | sed -n -e 's#^!! ##p' | xargs -r rm -vrf"
+        "cleanup": "git status --short --ignored | sed -n -e 's#^!! ##p' | xargs -r rm -vrf",
+        "test": [
+            "@test:phpstan",
+            "@test:phpunit"
+        ],
+        "test:phpstan": "phpstan analyze",
+        "test:phpunit": "phpunit"
     },
     "scripts-descriptions": {
         "cleanup": "Remove all ignored files."

--- a/functionMap.php
+++ b/functionMap.php
@@ -83,6 +83,6 @@ return [
     'get_comment' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Comment|null))"],
     'get_post' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],
     'get_page_by_path' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],
-    'has_action' => ['($callback is false ? bool : bool|int)'],
-    'has_filter' => ['($callback is false ? bool : bool|int)'],
+    'has_action' => ['($callback is false ? bool : false|int)'],
+    'has_filter' => ['($callback is false ? bool : false|int)'],
 ];

--- a/functionMap.php
+++ b/functionMap.php
@@ -79,7 +79,7 @@ return [
     'mysql2date' => ["(\$format is 'G'|'U' ? int|false : string|false)"],
     'get_post_types' => ["(\$output is 'names' ? array<int, string> : array<int, \WP_Post_Type>)"],
     'get_taxonomies' => ["(\$output is 'names' ? array<int, string> : array<int, \WP_Taxonomy>)"],
-    'get_object_taxonomies' => ["(\$output is 'names' ? array<int, string> : array<int, \WP_Taxonomy>)"],
+    'get_object_taxonomies' => ["(\$output is 'names' ? array<int, string> : array<string, \WP_Taxonomy>)"],
     'get_comment' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Comment|null))"],
     'get_post' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],
     'get_page_by_path' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],

--- a/functionMap62.php
+++ b/functionMap62.php
@@ -83,6 +83,6 @@ return [
     'get_comment' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Comment|null))"],
     'get_post' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],
     'get_page_by_path' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],
-    'has_action' => ['($callback is false ? bool : bool|int)'],
-    'has_filter' => ['($callback is false ? bool : bool|int)'],
+    'has_action' => ['($callback is false ? bool : false|int)'],
+    'has_filter' => ['($callback is false ? bool : false|int)'],
 ];

--- a/functionMap62.php
+++ b/functionMap62.php
@@ -79,7 +79,7 @@ return [
     'mysql2date' => ["(\$format is 'G'|'U' ? int|false : string|false)"],
     'get_post_types' => ["(\$output is 'names' ? array<int, string> : array<int, \WP_Post_Type>)"],
     'get_taxonomies' => ["(\$output is 'names' ? array<int, string> : array<int, \WP_Taxonomy>)"],
-    'get_object_taxonomies' => ["(\$output is 'names' ? array<int, string> : array<int, \WP_Taxonomy>)"],
+    'get_object_taxonomies' => ["(\$output is 'names' ? array<int, string> : array<string, \WP_Taxonomy>)"],
     'get_comment' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Comment|null))"],
     'get_post' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],
     'get_page_by_path' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,6 @@ parameters:
     paths:
         - finder.php
         - visitor.php
+        - tests/
+    excludePaths:
+        - tests/data/

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         colors="true"
-         failOnRisky="true"
-         failOnWarning="true"
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    colors="true"
+    failOnRisky="true"
+    failOnWarning="true"
 >
     <testsuites>
         <testsuite name="main">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <testsuites>
+        <testsuite name="main">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordpressStubs\Tests;
+
+class TypeInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
+{
+    /** @return iterable<mixed> */
+    public function dataFileAsserts(): iterable
+    {
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/current_time.php');
+    }
+
+    /**
+     * @dataProvider dataFileAsserts
+     * @param array<string> ...$args
+     */
+    public function testFileAsserts(string $assertType, string $file, ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/phpstan.neon'];
+    }
+}

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -10,6 +10,7 @@ class TypeInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
     public function dataFileAsserts(): iterable
     {
         yield from $this->gatherAssertTypes(__DIR__ . '/data/current_time.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/has_filter.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql2date.php');
     }
 

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -10,6 +10,7 @@ class TypeInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
     public function dataFileAsserts(): iterable
     {
         yield from $this->gatherAssertTypes(__DIR__ . '/data/current_time.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql2date.php');
     }
 
     /**

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -10,6 +10,7 @@ class TypeInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
     public function dataFileAsserts(): iterable
     {
         yield from $this->gatherAssertTypes(__DIR__ . '/data/current_time.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_object_taxonomies.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/has_filter.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql2date.php');
     }

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WordpressStubs\Tests;
+namespace PhpStubs\WordPress\Core\Tests;
 
 class TypeInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
 {

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -11,6 +11,7 @@ class TypeInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
     {
         yield from $this->gatherAssertTypes(__DIR__ . '/data/current_time.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_object_taxonomies.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_taxonomies.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/has_filter.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql2date.php');
     }

--- a/tests/data/current_time.php
+++ b/tests/data/current_time.php
@@ -17,10 +17,7 @@ assertType('int', current_time('U'));
 assertType('string', current_time('mysql'));
 assertType('string', current_time('Hello'));
 
-// Unknown types
-assertType('int|string', current_time($_GET['foo']));
-assertType('int|string', current_time(get_option('date_format')));
-
-// Unsupported types
-assertType('string', current_time(new stdClass()));
-assertType('string', current_time(false));
+// Unknown string
+/** @var string $string */
+$string = null;
+assertType('int|string', current_time($string));

--- a/tests/data/current_time.php
+++ b/tests/data/current_time.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordpressStubs\Tests;
+
+use stdClass;
+
+use function current_time;
+use function PHPStan\Testing\assertType;
+
+// Integer types
+assertType('int', current_time('timestamp'));
+assertType('int', current_time('U'));
+
+// String types
+assertType('string', current_time('mysql'));
+assertType('string', current_time('Hello'));
+
+// Unknown types
+assertType('int|string', current_time($_GET['foo']));
+assertType('int|string', current_time(get_option('date_format')));
+
+// Unsupported types
+assertType('string', current_time(new stdClass()));
+assertType('string', current_time(false));

--- a/tests/data/current_time.php
+++ b/tests/data/current_time.php
@@ -16,6 +16,4 @@ assertType('string', current_time('mysql'));
 assertType('string', current_time('Hello'));
 
 // Unknown string
-/** @var string $string */
-$string = null;
-assertType('int|string', current_time($string));
+assertType('int|string', current_time((string)$_GET['unknown_string']));

--- a/tests/data/current_time.php
+++ b/tests/data/current_time.php
@@ -2,9 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WordpressStubs\Tests;
-
-use stdClass;
+namespace PhpStubs\WordPress\Core\Tests;
 
 use function current_time;
 use function PHPStan\Testing\assertType;

--- a/tests/data/get_comment.php
+++ b/tests/data/get_comment.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function get_comment;
+use function PHPStan\Testing\assertType;
+
+/** @var \WP_Comment|int $comment */
+$comment = $comment;
+
+// Default output
+assertType('WP_Comment|null', get_comment());
+assertType('WP_Comment|null', get_comment($comment));
+assertType('WP_Comment|null', get_comment($comment, OBJECT));
+
+// Unexpected output
+assertType('WP_Comment|null', get_comment($comment, 'Hello'));
+
+// Unknown output
+assertType('array|WP_Comment|null', get_comment($comment, $_GET['foo']));
+
+// Associative array output
+assertType('array<string, mixed>|null', get_comment($comment, ARRAY_A));
+
+// Numeric array output
+assertType('array<int, mixed>|null', get_comment($comment, ARRAY_N));

--- a/tests/data/get_object_taxonomies.php
+++ b/tests/data/get_object_taxonomies.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WordpressStubs\Tests;
+namespace PhpStubs\WordPress\Core\Tests;
 
 use function get_object_taxonomies;
 use function PHPStan\Testing\assertType;

--- a/tests/data/get_object_taxonomies.php
+++ b/tests/data/get_object_taxonomies.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordpressStubs\Tests;
+
+use function get_object_taxonomies;
+use function PHPStan\Testing\assertType;
+
+// Default output
+assertType('array<int, string>', get_object_taxonomies('post'));
+assertType('array<int, string>', get_object_taxonomies('post', 'names'));
+
+// Objects output
+assertType('array<string, WP_Taxonomy>', get_object_taxonomies('post', 'objects'));
+
+// Unexpected output
+assertType('array<string, WP_Taxonomy>', get_object_taxonomies('post', 'Hello'));
+
+// Unknown string
+/** @var string $string */
+$string = null;
+assertType('array<int|string, string|WP_Taxonomy>', get_object_taxonomies('post', $string));

--- a/tests/data/get_object_taxonomies.php
+++ b/tests/data/get_object_taxonomies.php
@@ -18,6 +18,4 @@ assertType('array<string, WP_Taxonomy>', get_object_taxonomies('post', 'objects'
 assertType('array<string, WP_Taxonomy>', get_object_taxonomies('post', 'Hello'));
 
 // Unknown string
-/** @var string $string */
-$string = null;
-assertType('array<int|string, string|WP_Taxonomy>', get_object_taxonomies('post', $string));
+assertType('array<int|string, string|WP_Taxonomy>', get_object_taxonomies('post', (string)$_GET['unknown_string']));

--- a/tests/data/get_taxonomies.php
+++ b/tests/data/get_taxonomies.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordpressStubs\Tests;
+
+use function get_object_taxonomies;
+use function PHPStan\Testing\assertType;
+
+// Default output
+assertType('array<int, string>', get_taxonomies([]));
+assertType('array<int, string>', get_object_taxonomies([], 'names'));
+
+// Objects output
+assertType('array<string, WP_Taxonomy>', get_object_taxonomies([], 'objects'));
+
+// Unexpected output
+assertType('array<string, WP_Taxonomy>', get_object_taxonomies([], 'Hello'));
+
+// Unknown string
+/** @var string $string */
+$string = null;
+assertType('array<int|string, string|WP_Taxonomy>', get_object_taxonomies([], $string));

--- a/tests/data/get_taxonomies.php
+++ b/tests/data/get_taxonomies.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WordpressStubs\Tests;
+namespace PhpStubs\WordPress\Core\Tests;
 
 use function get_object_taxonomies;
 use function PHPStan\Testing\assertType;

--- a/tests/data/get_taxonomies.php
+++ b/tests/data/get_taxonomies.php
@@ -18,6 +18,4 @@ assertType('array<string, WP_Taxonomy>', get_object_taxonomies([], 'objects'));
 assertType('array<string, WP_Taxonomy>', get_object_taxonomies([], 'Hello'));
 
 // Unknown string
-/** @var string $string */
-$string = null;
-assertType('array<int|string, string|WP_Taxonomy>', get_object_taxonomies([], $string));
+assertType('array<int|string, string|WP_Taxonomy>', get_object_taxonomies([], (string)$_GET['unknown_string']));

--- a/tests/data/has_filter.php
+++ b/tests/data/has_filter.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordpressStubs\Tests;
+
+use function has_action;
+use function has_filter;
+use function PHPStan\Testing\assertType;
+
+// Default callback of false
+assertType('bool', has_filter(''));
+assertType('bool', has_action(''));
+
+// Explicit callback of false
+assertType('bool', has_filter('', false));
+assertType('bool', has_action('', false));
+
+// Explicit callback
+assertType('int|false', has_filter('', 'intval'));
+assertType('int|false', has_action('', 'intval'));
+
+// Maybe false callback
+/** @var callable|string|array|false $callback */
+$callback = $_GET['callback'];
+assertType('bool|int', has_filter('', $callback));
+assertType('bool|int', has_action('', $callback));

--- a/tests/data/has_filter.php
+++ b/tests/data/has_filter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WordpressStubs\Tests;
+namespace PhpStubs\WordPress\Core\Tests;
 
 use function has_action;
 use function has_filter;

--- a/tests/data/mysql2date.php
+++ b/tests/data/mysql2date.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WordpressStubs\Tests;
+namespace PhpStubs\WordPress\Core\Tests;
 
 use function mysql2date;
 use function PHPStan\Testing\assertType;

--- a/tests/data/mysql2date.php
+++ b/tests/data/mysql2date.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordpressStubs\Tests;
+
+use function mysql2date;
+use function PHPStan\Testing\assertType;
+
+$time = '1970-01-01 00:00:00';
+
+// Constant strings
+assertType('int|false', mysql2date('G', $time));
+assertType('int|false', mysql2date('U', $time));
+assertType('string|false', mysql2date('Y-m-d H:i:s', $time));
+
+// Unknown string
+/** @var string $string */
+$string = null;
+assertType('int|string|false', mysql2date($string, $time));

--- a/tests/data/mysql2date.php
+++ b/tests/data/mysql2date.php
@@ -15,6 +15,4 @@ assertType('int|false', mysql2date('U', $time));
 assertType('string|false', mysql2date('Y-m-d H:i:s', $time));
 
 // Unknown string
-/** @var string $string */
-$string = null;
-assertType('int|string|false', mysql2date($string, $time));
+assertType('int|string|false', mysql2date((string)$_GET['unknown_string'], $time));

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -1,0 +1,3 @@
+parameters:
+    bootstrapFiles:
+        - ../wordpress-stubs.php


### PR DESCRIPTION
@IanDelMar @szepeviktor @johnbillion 

maybe this is useful to continue with https://github.com/szepeviktor/phpstan-wordpress/pull/182 / https://github.com/szepeviktor/phpstan-wordpress/issues/180?

still missing: phpcs and all the crazy CS rules that Viktor has in the extension repo 😊