### PR TITLE
Remove the need to maintain these args shapes

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -2,8 +2,6 @@
 
 $httpReturnType = 'array{headers: \Requests_Utility_CaseInsensitiveDictionary, body: string, response: array{code: int,message: string}, cookies: array<int, \WP_HTTP_Cookie>, filename: string|null, http_response: \WP_HTTP_Requests_Response}|\WP_Error';
 $cronArgsType = 'list<mixed>';
-$registerPostTypeArgsType = 'array{label?: string, labels?: string[], description?: string, public?: bool, hierarchical?: bool, exclude_from_search?: bool, publicly_queryable?: bool, show_ui?: bool, show_in_menu?: bool|string, show_in_nav_menus?: bool, show_in_admin_bar?: bool, show_in_rest?: bool, rest_base?: string, rest_namespace?: string, rest_controller_class?: string, menu_position?: int, menu_icon?: string, capability_type?: string|array, capabilities?: string[], map_meta_cap?: bool, supports?: array, register_meta_box_cb?: callable, taxonomies?: string[], has_archive?: bool|string, rewrite?: bool|array{slug?: string, with_front?: bool, feeds?: bool, pages?: bool, ep_mask?: int}, query_var?: string|bool, can_export?: bool, delete_with_user?: bool, template?: array, template_lock?: string|false, _builtin?: bool, _edit_link?: string}';
-$registerTaxonomyArgsType = 'array{labels?: string[], description?: string, public?: bool, publicly_queryable?: bool, hierarchical?: bool, show_ui?: bool, show_in_menu?: bool, show_in_nav_menus?: bool, show_in_rest?: bool, rest_base?: string, rest_namespace?: string, rest_controller_class?: string, show_tagcloud?: bool, show_in_quick_edit?: bool, show_admin_column?: bool, meta_box_cb?: bool|callable, meta_box_sanitize_cb?: callable, capabilities?: array{manage_terms?: string, edit_terms?: string, delete_terms?: string, assign_terms?: string}, rewrite?: bool|array{slug?: string, with_front?: bool, hierarchical?: bool, ep_mask?: int}, query_var?: string|bool, update_count_callback?: callable, default_term?: string|array{name?: string, slug?: string, description?: string}, sort?: bool, args?: array, _builtin?: bool}';
 $wpWidgetRssFormArgsType = 'array{number: int, error: bool, title?: string, url?: string, items?: int, show_summary?: int, show_author?: int, show_date?: int}';
 $wpWidgetRssFormInputType = 'array{title?: bool, url?: bool, items?: bool, show_summary?: bool, show_author?: bool, show_date?: bool}';
 
@@ -43,7 +41,7 @@ return [
     'WP_List_Table::pagination' => ['void', 'which'=>'"top"|"bottom"'],
     'WP_List_Table::set_pagination_args' => ['void', 'args'=>'array{total_items?: int, total_pages?: int, per_page?: int}'],
     'wp_next_scheduled' => ['int|false', 'args'=>$cronArgsType],
-    'WP_Post_Type::__construct' => ['void', 'args'=>$registerPostTypeArgsType],
+    'WP_Post_Type::__construct' => ['void', 'args'=>'array<string, mixed>'],
     'WP_Query::have_posts' => ['bool', '@phpstan-impure'=>''],
     'wp_remote_get' => [$httpReturnType],
     'wp_remote_head' => [$httpReturnType],
@@ -57,7 +55,7 @@ return [
     'wp_schedule_event' => ['bool|WP_Error', 'args'=>$cronArgsType],
     'wp_schedule_single_event' => ['bool|WP_Error', 'args'=>$cronArgsType],
     'wp_slash' => ['T', '@phpstan-template'=>'T', 'value'=>'T'],
-    'WP_Taxonomy::__construct' => ['void', 'args'=>$registerTaxonomyArgsType],
+    'WP_Taxonomy::__construct' => ['void', 'args'=>'array<string, mixed>'],
     'wp_unschedule_event' => ['bool|WP_Error', 'args'=>$cronArgsType],
     'wp_unslash' => ['T', '@phpstan-template'=>'T', 'value'=>'T'],
     'wp_widget_rss_form' => ['void', 'args'=>$wpWidgetRssFormArgsType, 'input'=>$wpWidgetRssFormInputType],

--- a/functionMap62.php
+++ b/functionMap62.php
@@ -2,8 +2,6 @@
 
 $httpReturnType = 'array{headers: \WpOrg\Requests\Utility\CaseInsensitiveDictionary, body: string, response: array{code: int,message: string}, cookies: array<int, \WP_HTTP_Cookie>, filename: string|null, http_response: \WP_HTTP_Requests_Response}|\WP_Error';
 $cronArgsType = 'list<mixed>';
-$registerPostTypeArgsType = 'array{label?: string, labels?: string[], description?: string, public?: bool, hierarchical?: bool, exclude_from_search?: bool, publicly_queryable?: bool, show_ui?: bool, show_in_menu?: bool|string, show_in_nav_menus?: bool, show_in_admin_bar?: bool, show_in_rest?: bool, rest_base?: string, rest_namespace?: string, rest_controller_class?: string, menu_position?: int, menu_icon?: string, capability_type?: string|array, capabilities?: string[], map_meta_cap?: bool, supports?: array, register_meta_box_cb?: callable, taxonomies?: string[], has_archive?: bool|string, rewrite?: bool|array{slug?: string, with_front?: bool, feeds?: bool, pages?: bool, ep_mask?: int}, query_var?: string|bool, can_export?: bool, delete_with_user?: bool, template?: array, template_lock?: string|false, _builtin?: bool, _edit_link?: string}';
-$registerTaxonomyArgsType = 'array{labels?: string[], description?: string, public?: bool, publicly_queryable?: bool, hierarchical?: bool, show_ui?: bool, show_in_menu?: bool, show_in_nav_menus?: bool, show_in_rest?: bool, rest_base?: string, rest_namespace?: string, rest_controller_class?: string, show_tagcloud?: bool, show_in_quick_edit?: bool, show_admin_column?: bool, meta_box_cb?: bool|callable, meta_box_sanitize_cb?: callable, capabilities?: array{manage_terms?: string, edit_terms?: string, delete_terms?: string, assign_terms?: string}, rewrite?: bool|array{slug?: string, with_front?: bool, hierarchical?: bool, ep_mask?: int}, query_var?: string|bool, update_count_callback?: callable, default_term?: string|array{name?: string, slug?: string, description?: string}, sort?: bool, args?: array, _builtin?: bool}';
 $wpWidgetRssFormArgsType = 'array{number: int, error: bool, title?: string, url?: string, items?: int, show_summary?: int, show_author?: int, show_date?: int}';
 $wpWidgetRssFormInputType = 'array{title?: bool, url?: bool, items?: bool, show_summary?: bool, show_author?: bool, show_date?: bool}';
 
@@ -43,7 +41,7 @@ return [
     'WP_List_Table::pagination' => ['void', 'which'=>'"top"|"bottom"'],
     'WP_List_Table::set_pagination_args' => ['void', 'args'=>'array{total_items?: int, total_pages?: int, per_page?: int}'],
     'wp_next_scheduled' => ['int|false', 'args'=>$cronArgsType],
-    'WP_Post_Type::__construct' => ['void', 'args'=>$registerPostTypeArgsType],
+    'WP_Post_Type::__construct' => ['void', 'args'=>'array<string, mixed>'],
     'WP_Query::have_posts' => ['bool', '@phpstan-impure'=>''],
     'wp_remote_get' => [$httpReturnType],
     'wp_remote_head' => [$httpReturnType],
@@ -57,7 +55,7 @@ return [
     'wp_schedule_event' => ['bool|WP_Error', 'args'=>$cronArgsType],
     'wp_schedule_single_event' => ['bool|WP_Error', 'args'=>$cronArgsType],
     'wp_slash' => ['T', '@phpstan-template'=>'T', 'value'=>'T'],
-    'WP_Taxonomy::__construct' => ['void', 'args'=>$registerTaxonomyArgsType],
+    'WP_Taxonomy::__construct' => ['void', 'args'=>'array<string, mixed>'],
     'wp_unschedule_event' => ['bool|WP_Error', 'args'=>$cronArgsType],
     'wp_unslash' => ['T', '@phpstan-template'=>'T', 'value'=>'T'],
     'wp_widget_rss_form' => ['void', 'args'=>$wpWidgetRssFormArgsType, 'input'=>$wpWidgetRssFormInputType],


### PR DESCRIPTION
@IanDelMar This simplifies these two parameter types so we don't need to maintain the shapes. What do you think?

In #81 I added `See register_post_type() for information on accepted arguments` and `See register_taxonomy() for information on accepted arguments` to the args descriptions in the constructors in WordPress core and then regenerated the stubs, to demonstrate how [the args inheritance](https://github.com/johnbillion/wordpress-stubs/blob/cf154052649f9b35a48fd9590a6a06333eda95fd/visitor.php#L567-L580) works. I can add those to core but we'll need to wait until WordPress 6.3 is released to benefit from them. This PR could be merged in the meantime.