### PR TITLE
Add conditional return type for `is_wp_error()`

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -77,7 +77,7 @@ return [
     'WP_Block_List::offsetGet' => ['WP_Block|null', 'index'=>'int'],
     'WP_Block_List::offsetSet' => ['void', 'index'=>'int|null'],
     'WP_Block_List::offsetUnset' => ['void', 'index'=>'int'],
-    'is_wp_error' => ['bool', '@phpstan-assert-if-true'=>'\WP_Error $thing'],
+    'is_wp_error' => ['($thing is \WP_Error ? true : false)', '@phpstan-assert-if-true'=>'\WP_Error $thing'],
     'current_time' => ["(\$type is 'timestamp'|'U' ? int : string)"],
     'mysql2date' => ["(\$format is 'G'|'U' ? int|false : string|false)"],
     'get_post_types' => ["(\$output is 'names' ? array<int, string> : array<int, \WP_Post_Type>)"],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -18,6 +18,7 @@ class TypeInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_permalink.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_taxonomies.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/has_filter.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/is_wp_error.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql2date.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_error_parameter.php');

--- a/tests/data/is_wp_error.php
+++ b/tests/data/is_wp_error.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use WP_Error;
+
+use function is_wp_error;
+use function PHPStan\Testing\assertType;
+
+assertType('false', is_wp_error((string)$_GET['thing']));
+assertType('true', is_wp_error(new WP_Error()));
+assertType('bool', is_wp_error($_GET['thing']));

--- a/tests/data/is_wp_error.php
+++ b/tests/data/is_wp_error.php
@@ -12,3 +12,6 @@ use function PHPStan\Testing\assertType;
 assertType('false', is_wp_error((string)$_GET['thing']));
 assertType('true', is_wp_error(new WP_Error()));
 assertType('bool', is_wp_error($_GET['thing']));
+if (is_wp_error($_GET['thing'])) {
+    assertType('WP_Error', $_GET['thing']);
+}


### PR DESCRIPTION
I'm not sure what the benefit of `'@phpstan-assert-if-true'=>'\WP_Error $thing'` is, so I left it as is.