### PR TITLE
Add support for object shapes in PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "nikic/php-parser": "< 4.12.0",
         "php-stubs/generator": "^0.8.3",
         "phpdocumentor/reflection-docblock": "^5.3",
-        "phpstan/phpstan": "^1.9",
+        "phpstan/phpstan": "^1.10.12",
         "phpunit/phpunit": "^9.5"
     },
     "suggest": {

--- a/visitor.php
+++ b/visitor.php
@@ -787,14 +787,33 @@ return new class extends NodeVisitor {
             return null;
         }
 
-        if (strpos($tagVariableType, 'array') === false) {
-            // Skip if we have hash notation that's not for an array (ie. for `object`).
+        $tagVariableType = str_replace([
+            'stdClass',
+            '\\object',
+        ], 'object', $tagVariableType);
+        $hasSupportedType = false;
+        $supportedTypes = [
+            'object',
+            'array',
+        ];
+
+        foreach ($supportedTypes as $supportedType) {
+            if (strpos($tagVariableType, $supportedType) !== false) {
+                $hasSupportedType = true;
+                break;
+            }
+        }
+
+        if (! $hasSupportedType) {
+            // Skip if we have hash notation for a type that's not supported.
             return null;
         }
 
-        if (strpos($tagVariableType, 'array|') !== false) {
-            // Move `array` to the end of union types so the appended array shape works.
-            $tagVariableType = str_replace('array|', '', $tagVariableType) . '|array';
+        foreach ($supportedTypes as $supportedType) {
+            if (strpos($tagVariableType, "{$supportedType}|") !== false) {
+                // Move the type that uses the hash notation to the end of union types so the shape works.
+                $tagVariableType = str_replace("{$supportedType}|", '', $tagVariableType) . "|{$supportedType}";
+            }
         }
 
         return $tagVariableType;

--- a/visitor.php
+++ b/visitor.php
@@ -791,23 +791,10 @@ return new class extends NodeVisitor {
             'stdClass',
             '\\object',
         ], 'object', $tagVariableType);
-        $hasSupportedType = false;
         $supportedTypes = [
             'object',
             'array',
         ];
-
-        foreach ($supportedTypes as $supportedType) {
-            if (strpos($tagVariableType, $supportedType) !== false) {
-                $hasSupportedType = true;
-                break;
-            }
-        }
-
-        if (! $hasSupportedType) {
-            // Skip if we have hash notation for a type that's not supported.
-            return null;
-        }
 
         foreach ($supportedTypes as $supportedType) {
             if (strpos($tagVariableType, "{$supportedType}|") !== false) {


### PR DESCRIPTION
Ref: https://github.com/phpstan/phpstan/releases/tag/1.10.12

Not especially useful at the moment, but hey. There are a few other undocumented objects in WordPress core, I'll try to get them documented for 6.3.