### PR TITLE
Add dynamic return type for the get_term function

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -90,6 +90,7 @@ return [
     'get_comment' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Comment|null))"],
     'get_post' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],
     'get_page_by_path' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],
+    'get_term' => ["(\$output is 'ARRAY_A' ? array<string, string|int>|\WP_Error|null : (\$output is 'ARRAY_N' ? list<string|int>|\WP_Error|null : \WP_Term|\WP_Error|null))"],
     'has_action' => ['($callback is false ? bool : false|int)'],
     'has_filter' => ['($callback is false ? bool : false|int)'],
     'get_permalink' => ['($post is \WP_Post ? string : string|false)'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -20,6 +20,7 @@ class TypeInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_page_by_path.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_permalink.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_taxonomies.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_term.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_taxonomies_for_attachments.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/has_filter.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/is_wp_error.php');

--- a/tests/data/get_term.php
+++ b/tests/data/get_term.php
@@ -1,0 +1,17 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function get_term;
+use function PHPStan\Testing\assertType;
+
+assertType( 'WP_Error|WP_Term|null', get_term( 2, '', OBJECT ) );
+assertType( 'WP_Error|WP_Term|null', get_term( 2, 'category', OBJECT ) );
+assertType( 'WP_Error|WP_Term|null', get_term( 2 ) );
+
+assertType( 'array<string, int|string>|WP_Error|null', get_term( 2, '', ARRAY_A ) );
+assertType( 'array<string, int|string>|WP_Error|null', get_term( 2, 'category', ARRAY_A ) );
+assertType( 'array<int, int|string>|WP_Error|null', get_term( 2, '', ARRAY_N ) );
+assertType( 'array<int, int|string>|WP_Error|null', get_term( 2, 'category', ARRAY_N ) );


### PR DESCRIPTION
- Return `array<int|string>` if `$output = 'ARRAY_N'`.
- Return `array<string, int|string>` if default or `$output = 'ARRAY_A'`.
- Return `WP_Term` if default or `$output = 'OBJECT'`.

link https://developer.wordpress.org/reference/functions/get_term/#parameters