### PR TITLE
Add dynamic return type for the get_term_by function

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -89,6 +89,7 @@ return [
     'get_post_stati' => ["(\$output is 'names' ? array<string, string> : array<string, \stdClass>)"],
     'get_comment' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Comment|null))"],
     'get_post' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],
+    'get_term_by' => ["(\$output is 'ARRAY_A' ? array<string, string|int>|\WP_Error|false : (\$output is 'ARRAY_N' ? list<string|int>|\WP_Error|false : \WP_Term|\WP_Error|false))"],
     'get_page_by_path' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],
     'has_action' => ['($callback is false ? bool : false|int)'],
     'has_filter' => ['($callback is false ? bool : false|int)'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -19,6 +19,7 @@ class TypeInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_post_types.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_page_by_path.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_permalink.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_term_by.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_taxonomies.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_taxonomies_for_attachments.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/has_filter.php');

--- a/tests/data/get_term_by.php
+++ b/tests/data/get_term_by.php
@@ -1,0 +1,13 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function get_term_by;
+use function PHPStan\Testing\assertType;
+
+assertType( 'WP_Error|WP_Term|false', get_term_by( 'term_id', 2, '', OBJECT ) );
+assertType( 'WP_Error|WP_Term|false', get_term_by( 'slug', 'test' ) );
+assertType( 'array<string, int|string>|WP_Error|false', get_term_by( 'term_id', 2, '', ARRAY_A ) );
+assertType( 'array<int, int|string>|WP_Error|false', get_term_by( 'term_id', 2, '', ARRAY_N ) );


### PR DESCRIPTION
- Return `array<int|string>` if `$output = 'ARRAY_N'`.
- Return `array<string, int|string>` if default or `$output = 'ARRAY_A'`.
- Return `WP_Term` if default or `$output = 'OBJECT'`.

link https://developer.wordpress.org/reference/functions/get_term_by/#parameters