### PR TITLE
Fix type in variable docblock

### DIFF
--- a/visitor.php
+++ b/visitor.php
@@ -289,7 +289,6 @@ return new class extends NodeVisitor {
 
     public function enterNode(Node $node)
     {
-
         $neverReturn = self::isNeverReturn($node);
 
         parent::enterNode($node);
@@ -307,7 +306,7 @@ return new class extends NodeVisitor {
         $symbolName = self::getNodeName($node);
 
         if ($node instanceof ClassMethod) {
-            /** @var \PhpParser\Node\Stmt\Class_ $parent */
+            /** @var \PhpParser\Node\Stmt\ClassLike $parent */
             $parent = $this->stack[count($this->stack) - 2];
 
             if (isset($parent->name)) {


### PR DESCRIPTION
Although we leave `Interface_` and `Trait_` nodes at this point
https://github.com/php-stubs/wordpress-stubs/blob/c0a1041ddd384b5224bc8b90e7d1adcc9ef5d11c/visitor.php#L297-L299
we continue traversing to check their methods. Therefore, the parent node of each `ClassMethod` can be either a `Class_`, `Interface_` or `Trait_` node, i.e. a `ClassLike` node.