### PR TITLE
Remove obsolete isset()

### DIFF
--- a/visitor.php
+++ b/visitor.php
@@ -1006,7 +1006,7 @@ return new class extends NodeVisitor {
             if (is_numeric($nameTrimmed)) {
                 $optionalArg = false;
             } elseif ($optional && ($level > 1)) {
-                $optionalArg = isset($parts[2]) && self::isOptional($parts[2]);
+                $optionalArg = self::isOptional($parts[2]);
             }
 
             if (strpos($name, '...$') !== false) {


### PR DESCRIPTION
By
https://github.com/php-stubs/wordpress-stubs/blob/1bb52f7ab7eebe2a72b50f62a16cf68e8b577ed7/visitor.php#L997-L999
we know that `$parts[2]` is set.