### PR TITLE
Remove wp_clear_scheduled_hook from TypeInferenceTest

### DIFF
--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -30,7 +30,6 @@ class TypeInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/is_wp_error.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql2date.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_clear_scheduled_hook.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_error_parameter.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_theme.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wpdb.php');


### PR DESCRIPTION
#129 