### PR TITLE
Remove `get_objects_in_term()` from functionMap

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -23,7 +23,6 @@ $filesystemDirlistReturnType = "false|array<string, array{name: string, perms: s
  */
 return [
     'addslashes_gpc' => ['T', '@phpstan-template' => 'T', 'gpc' => 'T'],
-    'get_objects_in_term' => [null, 'args' => 'array{order?: string}'],
     'have_posts' => [null, '@phpstan-impure' => ''],
     'rawurlencode_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'sanitize_category' => ['T', '@phpstan-template' => 'T of array|object', 'category' => 'T'],


### PR DESCRIPTION
`get_objects_in_term()` gets added twice. Spotted via tests added in #128.