### PR TITLE
Exclude "must be overriden" from adding return never

### DIFF
--- a/visitor.php
+++ b/visitor.php
@@ -26,6 +26,7 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Return_ as Stmt_Return;
+use PhpParser\NodeDumper;
 use StubsGenerator\NodeVisitor;
 
 abstract class WithChildren
@@ -1050,6 +1051,11 @@ return new class extends NodeVisitor {
             }
             // If a first level statement is exit/die, it's return type never.
             if ($stmt->expr instanceof Exit_) {
+                if ($stmt->expr->expr instanceof String_) {
+                    if (strpos($stmt->expr->expr->value, 'must be overridden') !== false) {
+                        return '';
+                    }
+                }
                 return 'never';
             }
             if (!($stmt->expr instanceof FuncCall) || !($stmt->expr->name instanceof Name)) {

--- a/visitor.php
+++ b/visitor.php
@@ -26,7 +26,6 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Return_ as Stmt_Return;
-use PhpParser\NodeDumper;
 use StubsGenerator\NodeVisitor;
 
 abstract class WithChildren


### PR DESCRIPTION
https://github.com/php-stubs/wordpress-stubs/pull/110#issuecomment-1801824738
https://github.com/php-stubs/wordpress-stubs/pull/110#issuecomment-1802758520