### PR TITLE
Get rid of complex conditions in visitor.php

### DIFF
--- a/visitor.php
+++ b/visitor.php
@@ -199,21 +199,21 @@ final class WordPressArg extends WithChildren
         }
 
         if ($this->isArrayShape()) {
-            if ($this->name !== null) {
-                $strings[] = sprintf(
-                    '%s%s%s: %s{',
-                    $padding,
-                    $this->name,
-                    ($this->optional) ? '?' : '',
-                    $this->type
-                );
+            if ($this->name === null) {
+                $strings = array_merge($strings, $childStrings);
+
+                return $strings;
             }
 
+            $strings[] = sprintf(
+                '%s%s%s: %s{',
+                $padding,
+                $this->name,
+                ($this->optional) ? '?' : '',
+                $this->type
+            );
             $strings = array_merge($strings, $childStrings);
-
-            if ($this->name !== null) {
-                $strings[] = sprintf('%s},', $padding);
-            }
+            $strings[] = sprintf('%s},', $padding);
 
             return $strings;
         }
@@ -226,9 +226,7 @@ final class WordPressArg extends WithChildren
             ($this->optional) ? '?' : '',
             $this->type
         );
-
         $strings = array_merge($strings, $childStrings);
-
         $strings[] = sprintf('%s}>,', $padding);
 
         return $strings;

--- a/visitor.php
+++ b/visitor.php
@@ -208,25 +208,28 @@ final class WordPressArg extends WithChildren
                     $this->type
                 );
             }
-        } else {
-            $strings[] = sprintf(
-                '%s%s%s: array<int|string, %s{',
-                $padding,
-                $this->name,
-                ($this->optional) ? '?' : '',
-                $this->type
-            );
+
+            $strings = array_merge($strings, $childStrings);
+
+            if ($this->name !== null) {
+                $strings[] = sprintf('%s},', $padding);
+            }
+
+            return $strings;
         }
+
+        // Not an array with a shape
+        $strings[] = sprintf(
+            '%s%s%s: array<int|string, %s{',
+            $padding,
+            $this->name,
+            ($this->optional) ? '?' : '',
+            $this->type
+        );
 
         $strings = array_merge($strings, $childStrings);
 
-        if ($this->isArrayShape()) {
-            if ($this->name !== null) {
-                $strings[] = "$padding},";
-            }
-        } else {
-            $strings[] = "$padding}>,";
-        }
+        $strings[] = sprintf('%s}>,', $padding);
 
         return $strings;
     }

--- a/visitor.php
+++ b/visitor.php
@@ -176,47 +176,7 @@ final class WordPressArg extends WithChildren
             return [];
         }
 
-        if (count($this->children) > 0) {
-            $childStrings = [];
-
-            foreach ($this->children as $child) {
-                $childStrings = array_merge($childStrings, $child->format($level + 1));
-            }
-
-            if (count($childStrings) === 0) {
-                return [];
-            }
-
-            if ($this->isArrayShape()) {
-                if ($this->name !== null) {
-                    $strings[] = sprintf(
-                        '%s%s%s: %s{',
-                        $padding,
-                        $this->name,
-                        ($this->optional) ? '?' : '',
-                        $this->type
-                    );
-                }
-            } else {
-                $strings[] = sprintf(
-                    '%s%s%s: array<int|string, %s{',
-                    $padding,
-                    $this->name,
-                    ($this->optional) ? '?' : '',
-                    $this->type
-                );
-            }
-
-            $strings = array_merge($strings, $childStrings);
-
-            if ($this->isArrayShape()) {
-                if ($this->name !== null) {
-                    $strings[] = "$padding},";
-                }
-            } else {
-                $strings[] = "$padding}>,";
-            }
-        } else {
+        if (count($this->children) === 0) {
             $strings[] = sprintf(
                 '%s%s%s: %s,',
                 $padding,
@@ -224,6 +184,48 @@ final class WordPressArg extends WithChildren
                 ($this->optional) ? '?' : '',
                 $this->type
             );
+
+            return $strings;
+        }
+
+        $childStrings = [];
+
+        foreach ($this->children as $child) {
+            $childStrings = array_merge($childStrings, $child->format($level + 1));
+        }
+
+        if (count($childStrings) === 0) {
+            return [];
+        }
+
+        if ($this->isArrayShape()) {
+            if ($this->name !== null) {
+                $strings[] = sprintf(
+                    '%s%s%s: %s{',
+                    $padding,
+                    $this->name,
+                    ($this->optional) ? '?' : '',
+                    $this->type
+                );
+            }
+        } else {
+            $strings[] = sprintf(
+                '%s%s%s: array<int|string, %s{',
+                $padding,
+                $this->name,
+                ($this->optional) ? '?' : '',
+                $this->type
+            );
+        }
+
+        $strings = array_merge($strings, $childStrings);
+
+        if ($this->isArrayShape()) {
+            if ($this->name !== null) {
+                $strings[] = "$padding},";
+            }
+        } else {
+            $strings[] = "$padding}>,";
         }
 
         return $strings;


### PR DESCRIPTION
@IanDelMar Please review my commits one-by-one.
I have zero clue what I am doing.

The first one: https://github.com/php-stubs/wordpress-stubs/pull/137/commits/8acda8ed6c29b23a1cc6a0669fbd2573276430d5?diff=unified&w=1
Second: https://github.com/php-stubs/wordpress-stubs/pull/137/commits/df08a1eb22c42ed76cff74e6d2c40a98bf396d2e?diff=unified&w=1
3rd: https://github.com/php-stubs/wordpress-stubs/pull/137/commits/afb2a10db1a0de0b911b9fc27805923f9a0ef287?diff=unified&w=1