### PR TITLE
CS vs. visitor.php

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,7 @@
 <ruleset>
     <file>finder.php</file>
     <file>functionMap.php</file>
-    <!-- <file>visitor.php</file> -->
+    <file>visitor.php</file>
 
     <rule ref="PSR12NeutronRuleset">
         <exclude name="Generic.Files.LineLength"/>


### PR DESCRIPTION
```
----------------------------------------------------------------------

   1 | WARNING | [ ] A file should declare new symbols (classes,

     |         |     functions, constants, etc.) and cause no other

     |         |     side effects, or it should execute logic with

     |         |     side effects, but should not do both. The first

     |         |     symbol is defined on line 30 and the first side

     |         |     effect is on line 234.

  30 | ERROR   | [ ] Each class must be in a namespace of at least

     |         |     one level (a top-level vendor name)

  30 | ERROR   | [ ] Class name doesn't match filename; expected

     |         |     "class visitor"

  67 | WARNING | [ ] Only one object structure is allowed in a file

  67 | ERROR   | [ ] Each class must be in a file by itself

  67 | ERROR   | [ ] Each class must be in a namespace of at least

     |         |     one level (a top-level vendor name)

  67 | ERROR   | [ ] Class name doesn't match filename; expected

     |         |     "class visitor"

  84 | WARNING | [ ] Function is longer than 40 lines

 132 | ERROR   | [x] Use early exit instead of "else".

 158 | WARNING | [ ] Only one object structure is allowed in a file

 158 | ERROR   | [ ] Each class must be in a file by itself

 158 | ERROR   | [ ] Each class must be in a namespace of at least

     |         |     one level (a top-level vendor name)

 158 | ERROR   | [ ] Class name doesn't match filename; expected

     |         |     "class visitor"

 170 | WARNING | [ ] Function is longer than 40 lines

 234 | ERROR   | [x] Parenthesis should always be used when

     |         |     instantiating a new object.

 256 | WARNING | [ ] Return type is missing

 256 | WARNING | [ ] Function is longer than 40 lines

 275 | ERROR   | [x] Use assertion instead of inline documentation

     |         |     comment.

 387 | ERROR   | [x] Use early exit to reduce code nesting.

 395 | WARNING | [ ] Function is longer than 40 lines

 426 | ERROR   | [x] Use early exit to reduce code nesting.

 438 | ERROR   | [x] Use early exit to reduce code nesting.

 450 | ERROR   | [x] Use early exit to reduce code nesting.

 482 | WARNING | [ ] Concat operator is prohibited

 565 | WARNING | [ ] The use of function list() is discouraged

 587 | ERROR   | [x] Use early exit to reduce code nesting.

 634 | WARNING | [ ] Concat operator is prohibited

 843 | WARNING | [ ] The use of function list() is discouraged

 848 | WARNING | [ ] The use of function list() is discouraged

 853 | WARNING | [ ] Concat operator is prohibited

 853 | WARNING | [ ] Concat operator is prohibited

 890 | WARNING | [ ] Concat operator is prohibited

 915 | WARNING | [ ] Function is longer than 40 lines

 935 | WARNING | [ ] The use of function list() is discouraged

 985 | WARNING | [ ] Function is longer than 40 lines

----------------------------------------------------------------------
```
