### PR TITLE
Enable PHPStan listType and alwaysTrueAlwaysReported

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,3 +7,6 @@ parameters:
         - tests/
     excludePaths:
         - tests/data/
+    featureToggles:
+        alwaysTrueAlwaysReported: true
+        instanceofType: true

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,4 @@
 parameters:
-    level: 8
     paths:
         - finder.php
         - functionMap.php
@@ -7,6 +6,7 @@ parameters:
         - tests/
     excludePaths:
         - tests/data/
+    level: 8
     featureToggles:
         alwaysTrueAlwaysReported: true
         instanceofType: true

--- a/visitor.php
+++ b/visitor.php
@@ -347,7 +347,7 @@ return new class extends NodeVisitor {
     }
 
     /**
-     * @return list<\PhpParser\Node>
+     * @return array<\PhpParser\Node>
      */
     public function getStubStmts(): array
     {
@@ -434,10 +434,6 @@ return new class extends NodeVisitor {
         $additions = [];
 
         foreach ($params as $param) {
-            if (! $param instanceof Param) {
-                continue;
-            }
-
             $addition = self::getAdditionFromParam($param);
 
             if ($addition !== null) {
@@ -446,10 +442,6 @@ return new class extends NodeVisitor {
         }
 
         foreach ($returns as $return) {
-            if (! $return instanceof Return_) {
-                continue;
-            }
-
             $addition = self::getAdditionFromReturn($return);
 
             if ($addition !== null) {
@@ -458,10 +450,6 @@ return new class extends NodeVisitor {
         }
 
         foreach ($vars as $var) {
-            if (! $var instanceof Var_) {
-                continue;
-            }
-
             $addition = self::getAdditionFromVar($var);
 
             if ($addition !== null) {


### PR DESCRIPTION
all the cool guys use this

no, it's just the latest feature toggles enabled basically, https://phpstan.org/config-reference#bleeding-edge
e.g. gives us the list type. and it showed dead code here.

this basically includes https://github.com/php-stubs/wordpress-stubs/pull/106