### PR TITLE
Fix wpdb::get_results() return type

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -128,7 +128,7 @@ return [
     'WP_Filesystem_ftpsockets::dirlist' => [$filesystemDirlistReturnType],
     'wpdb::prepare' => [null, 'query' => 'literal-string'],
     'wpdb::get_row' => ["null|void|(\$output is 'ARRAY_A' ? array<string, mixed> : (\$output is 'ARRAY_N' ? array<int, mixed> : \stdClass))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'", 'y' => '0|positive-int'],
-    'wpdb::get_results' => ["null|(\$output is 'ARRAY_A' ? array<string, mixed> : (\$output is 'ARRAY_N' ? array<int, mixed> : (\$output is 'OBJECT_K' ? array<string, \stdClass> : \stdClass)))", 'output' => "'OBJECT'|'OBJECT_K'|'ARRAY_A'|'ARRAY_N'"],
+    'wpdb::get_results' => ["null|(\$output is 'ARRAY_A' ? list<array<array-key, mixed>> : (\$output is 'ARRAY_N' ? list<array<int, mixed>> : (\$output is 'OBJECT_K' ? array<array-key, \stdClass> : list<\stdClass>)))", 'output' => "'OBJECT'|'OBJECT_K'|'ARRAY_A'|'ARRAY_N'"],
     'get_bookmark' => ["null|(\$output is 'ARRAY_A' ? array<string, mixed> : (\$output is 'ARRAY_N' ? array<int, mixed> : \stdClass))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'"],
     'get_category' => ["(\$category is object ? array<array-key, mixed>|\WP_Term : array<array-key, mixed>|\WP_Term|\WP_Error|null) & (\$output is 'ARRAY_A' ? array<string, mixed>|\WP_Error|null : (\$output is 'ARRAY_N' ? array<int, mixed>|\WP_Error|null : \WP_Term|\WP_Error|null))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'"],
     'get_category_by_path' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|\WP_Error|null : (\$output is 'ARRAY_N' ? array<int, mixed>|\WP_Error|null : \WP_Term|\WP_Error|null))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'"],

--- a/functionMap.php
+++ b/functionMap.php
@@ -127,7 +127,7 @@ return [
     'WP_Filesystem_SSH2::dirlist' => [$filesystemDirlistReturnType],
     'WP_Filesystem_ftpsockets::dirlist' => [$filesystemDirlistReturnType],
     'wpdb::prepare' => [null, 'query' => 'literal-string'],
-    'wpdb::get_row' => ["null|void|(\$output is 'ARRAY_A' ? array<string, mixed> : (\$output is 'ARRAY_N' ? array<int, mixed> : \stdClass))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'", 'y' => '0|positive-int'],
+    'wpdb::get_row' => ["null|void|(\$output is 'ARRAY_A' ? array<array-key, mixed> : (\$output is 'ARRAY_N' ? list<mixed> : \stdClass))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'", 'y' => '0|positive-int'],
     'wpdb::get_results' => ["null|(\$output is 'ARRAY_A' ? list<array<array-key, mixed>> : (\$output is 'ARRAY_N' ? list<array<int, mixed>> : (\$output is 'OBJECT_K' ? array<array-key, \stdClass> : list<\stdClass>)))", 'output' => "'OBJECT'|'OBJECT_K'|'ARRAY_A'|'ARRAY_N'"],
     'get_bookmark' => ["null|(\$output is 'ARRAY_A' ? array<string, mixed> : (\$output is 'ARRAY_N' ? array<int, mixed> : \stdClass))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'"],
     'get_category' => ["(\$category is object ? array<array-key, mixed>|\WP_Term : array<array-key, mixed>|\WP_Term|\WP_Error|null) & (\$output is 'ARRAY_A' ? array<string, mixed>|\WP_Error|null : (\$output is 'ARRAY_N' ? array<int, mixed>|\WP_Error|null : \WP_Term|\WP_Error|null))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'"],

--- a/tests/data/wpdb.php
+++ b/tests/data/wpdb.php
@@ -14,8 +14,19 @@ assertType('array<string, mixed>|void|null', wpdb::get_row(null, 'ARRAY_A'));
 assertType('array<int, mixed>|void|null', wpdb::get_row(null, 'ARRAY_N'));
 
 // wpdb::get_results()
-assertType('stdClass|null', wpdb::get_results());
-assertType('stdClass|null', wpdb::get_results(null, 'OBJECT'));
-assertType('array<string, stdClass>|null', wpdb::get_results(null, 'OBJECT_K'));
-assertType('array<string, mixed>|null', wpdb::get_results(null, 'ARRAY_A'));
-assertType('array<int, mixed>|null', wpdb::get_results(null, 'ARRAY_N'));
+/*
+ *                       Any of ARRAY_A | ARRAY_N | OBJECT | OBJECT_K constants.
+ *                       ARRAY_A | ARRAY_N | OBJECT: return an array of rows indexed from 0 by SQL result row number.
+ *
+ *                       ARRAY_A: Each row is an associative array (column => value, ...),
+ *                       ARRAY_N: a numerically indexed array (0 => value, ...),
+ *                       OBJECT: an object ( ->column = value ), respectively.
+ *
+ *                       With OBJECT_K: return an associative array of row objects keyed by the value
+ *                       of each row's first column's value.
+ */
+assertType('array<int, array>|null', wpdb::get_results(null, 'ARRAY_A'));
+assertType('array<int, array<int, mixed>>|null', wpdb::get_results(null, 'ARRAY_N'));
+assertType('array<int, stdClass>|null', wpdb::get_results());
+assertType('array<int, stdClass>|null', wpdb::get_results(null, 'OBJECT'));
+assertType('array<stdClass>|null', wpdb::get_results(null, 'OBJECT_K'));

--- a/tests/data/wpdb.php
+++ b/tests/data/wpdb.php
@@ -10,7 +10,7 @@ use function PHPStan\Testing\assertType;
 // wpdb::get_row()
 assertType('stdClass|void|null', wpdb::get_row());
 assertType('stdClass|void|null', wpdb::get_row(null, 'OBJECT'));
-assertType('array<string, mixed>|void|null', wpdb::get_row(null, 'ARRAY_A'));
+assertType('array|void|null', wpdb::get_row(null, 'ARRAY_A'));
 assertType('array<int, mixed>|void|null', wpdb::get_row(null, 'ARRAY_N'));
 
 // wpdb::get_results()

--- a/tests/data/wpdb.php
+++ b/tests/data/wpdb.php
@@ -14,17 +14,6 @@ assertType('array<string, mixed>|void|null', wpdb::get_row(null, 'ARRAY_A'));
 assertType('array<int, mixed>|void|null', wpdb::get_row(null, 'ARRAY_N'));
 
 // wpdb::get_results()
-/*
- *                       Any of ARRAY_A | ARRAY_N | OBJECT | OBJECT_K constants.
- *                       ARRAY_A | ARRAY_N | OBJECT: return an array of rows indexed from 0 by SQL result row number.
- *
- *                       ARRAY_A: Each row is an associative array (column => value, ...),
- *                       ARRAY_N: a numerically indexed array (0 => value, ...),
- *                       OBJECT: an object ( ->column = value ), respectively.
- *
- *                       With OBJECT_K: return an associative array of row objects keyed by the value
- *                       of each row's first column's value.
- */
 assertType('array<int, array>|null', wpdb::get_results(null, 'ARRAY_A'));
 assertType('array<int, array<int, mixed>>|null', wpdb::get_results(null, 'ARRAY_N'));
 assertType('array<int, stdClass>|null', wpdb::get_results());


### PR DESCRIPTION
Based on https://github.com/php-stubs/wordpress-stubs/pull/145

Closes https://github.com/php-stubs/wordpress-stubs/issues/143 

I'll do the list in another follow-up, the changes are bigger than I thought and blow the PR up unnecessarily I think