### PR TITLE
Improve return type for `get_post_types`

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -77,7 +77,7 @@ return [
     'is_wp_error' => ['($thing is \WP_Error ? true : false)', '@phpstan-assert-if-true' => '\WP_Error $thing'],
     'current_time' => ["(\$type is 'timestamp'|'U' ? int : string)"],
     'mysql2date' => ["(\$format is 'G'|'U' ? int|false : string|false)"],
-    'get_post_types' => ["(\$output is 'names' ? array<int, string> : array<int, \WP_Post_Type>)"],
+    'get_post_types' => ["(\$output is 'names' ? array<string, string> : array<string, \WP_Post_Type>)"],
     'get_taxonomies' => ["(\$output is 'names' ? array<int, string> : array<int, \WP_Taxonomy>)"],
     'get_object_taxonomies' => ["(\$output is 'names' ? array<int, string> : array<string, \WP_Taxonomy>)"],
     'get_attachment_taxonomies' => ["(\$output is 'names' ? array<int, string> : array<string, \WP_Taxonomy>)"],

--- a/tests/data/get_post_types.php
+++ b/tests/data/get_post_types.php
@@ -8,14 +8,14 @@ use function get_post_types;
 use function PHPStan\Testing\assertType;
 
 // Default output
-assertType('array<int, string>', get_post_types([]));
-assertType('array<int, string>', get_post_types([], 'names'));
+assertType('array<string, string>', get_post_types([]));
+assertType('array<string, string>', get_post_types([], 'names'));
 
 // Objects output
-assertType('array<int, WP_Post_Type>', get_post_types([], 'objects'));
+assertType('array<string, WP_Post_Type>', get_post_types([], 'objects'));
 
 // Unknown string
-assertType('array<int, string|WP_Post_Type>', get_post_types([], (string)$_GET['unknown_string']));
+assertType('array<string, string|WP_Post_Type>', get_post_types([], (string)$_GET['unknown_string']));
 
 // Unexpected output
-assertType('array<int, WP_Post_Type>', get_post_types([], 'Hello'));
+assertType('array<string, WP_Post_Type>', get_post_types([], 'Hello'));


### PR DESCRIPTION
The result of `get_post_type` is an associative array keyed with the post type slugs.