### PR TITLE
Generate stubs for WordPress 6.4.3

### DIFF
--- a/source/composer.json
+++ b/source/composer.json
@@ -7,7 +7,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "ext-sodium": "*",
-        "johnpbloch/wordpress": "6.4.2"
+        "johnpbloch/wordpress": "6.4.3"
     },
     "minimum-stability": "stable",
     "config": {


### PR DESCRIPTION
hmm, no difference apparently, not sure what you normally do with this..

thx for the quick merges btw!