### PR TITLE
Fix $callback type for `add_submenu_page`

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -25,6 +25,7 @@ $filesystemDirlistReturnType = "false|array<string, array{name: string, perms: s
  */
 return [
     'addslashes_gpc' => ['T', '@phpstan-template' => 'T', 'gpc' => 'T'],
+    'add_submenu_page' => [null, 'callback' => "''|callable"],
     'have_posts' => [null, '@phpstan-impure' => ''],
     'rawurlencode_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'sanitize_category' => ['T', '@phpstan-template' => 'T of array|object', 'category' => 'T'],


### PR DESCRIPTION
The default type for $callback is ''. Since there are parameters after $callback, we must support the default as well.

Fixes issue #153