### PR TITLE
Lock phpdocumentor/reflection-docblock version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "nikic/php-parser": "^4.13",
         "php-stubs/generator": "^0.8.3",
-        "phpdocumentor/reflection-docblock": "^5.3",
+        "phpdocumentor/reflection-docblock": "5.3",
         "phpstan/phpstan": "^1.10.49",
         "phpunit/phpunit": "^9.5",
         "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.11"


### PR DESCRIPTION
The release of [phpDocumentor/ReflectionDocBlock v5.4.0](https://github.com/phpDocumentor/ReflectionDocBlock/releases/tag/5.4.0) seems to have introduced an issue affecting the visitor functionality. Numerous `@phpstan-param` and `@phpstan-return` annotations are no longer present. Further investigation is needed. Locking the version at 5.3.0 is as a temporary measure until the issue is resolved.