### PR TITLE
Raise PHPStan level to 9

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,7 +7,7 @@ parameters:
         - tests/
     excludePaths:
         - tests/data/
-    level: 8
+    level: 9
     featureToggles:
         alwaysTrueAlwaysReported: true
         listType: true

--- a/src/Visitor.php
+++ b/src/Visitor.php
@@ -157,9 +157,10 @@ class Visitor extends NodeVisitor
             return;
         }
 
-        $name = $node->getAttribute('fullSymbolName');
+        /** @var ?string $fullSymbolName */
+        $fullSymbolName = $node->getAttribute('fullSymbolName');
 
-        if ($name === null) {
+        if ($fullSymbolName === null) {
             return;
         }
 
@@ -169,13 +170,13 @@ class Visitor extends NodeVisitor
             return;
         }
 
-        $newDocComment = $this->addTags($name, $docComment);
+        $newDocComment = $this->addTags($fullSymbolName, $docComment);
 
         if ($newDocComment instanceof Doc) {
             $node->setDocComment($newDocComment);
         }
 
-        if (! isset($this->additionalTagStrings[$name])) {
+        if (! isset($this->additionalTagStrings[$fullSymbolName])) {
             return;
         }
 
@@ -185,7 +186,7 @@ class Visitor extends NodeVisitor
             return;
         }
 
-        $newDocComment = $this->addStringTags($name, $docComment);
+        $newDocComment = $this->addStringTags($fullSymbolName, $docComment);
 
         if (! ($newDocComment instanceof Doc)) {
             return;

--- a/src/Visitor.php
+++ b/src/Visitor.php
@@ -35,8 +35,8 @@ class Visitor extends NodeVisitor
 {
     private \phpDocumentor\Reflection\DocBlockFactory $docBlockFactory;
 
-    /** @var ?array<string,array<int|string,string>> */
-    private ?array $functionMap = null;
+    /** @var array<string,array<int|string,string>> */
+    private array $functionMap;
 
     /** @var array<string, list<\PhpStubs\WordPress\Core\WordPressTag>> */
     private array $additionalTags = [];
@@ -50,6 +50,7 @@ class Visitor extends NodeVisitor
     {
         $this->docBlockFactory = \phpDocumentor\Reflection\DocBlockFactory::createInstance();
         $this->nodeFinder = new NodeFinder();
+        $this->functionMap = require sprintf('%s/functionMap.php', dirname(__DIR__));
     }
 
     /**
@@ -426,16 +427,14 @@ class Visitor extends NodeVisitor
      */
     private function getAdditionalTagsFromMap(string $symbolName): array
     {
-        if ($this->functionMap === null) {
-            $this->functionMap = require sprintf('%s/functionMap.php', dirname(__DIR__));
-        }
-
-        if (! isset($this->functionMap[$symbolName])) {
+        if (! array_key_exists($symbolName, $this->functionMap)) {
             return [];
         }
 
         $parameters = $this->functionMap[$symbolName];
         $returnType = array_shift($parameters);
+        /** @var array<string, string> $parameters */
+
         $additions = [];
 
         foreach ($parameters as $paramName => $paramType) {

--- a/src/Visitor.php
+++ b/src/Visitor.php
@@ -22,9 +22,11 @@ use PhpParser\Node\Expr\Exit_;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Return_ as Stmt_Return;
 use StubsGenerator\NodeVisitor;
@@ -147,7 +149,7 @@ class Visitor extends NodeVisitor
 
     private function postProcessNode(Node $node): void
     {
-        if (property_exists($node, 'stmts') && is_array($node->stmts)) {
+        if ($node instanceof ClassLike || $node instanceof Namespace_) {
             foreach ($node->stmts as $stmt) {
                 $this->postProcessNode($stmt);
             }


### PR DESCRIPTION
* (Not related to level 9) Requires `functionMap.php` in the constructor. We hardly gain anything by doing this in `getAdditionalTagsFromMap()`. Adds a doc comment to inform PHPStan of the type change after `array_shift()`.
* Renames `$name` to `$fullSymbolName` to indicate what name the variable holds throughout the method. Adds a doc comment to `$fullSymbolName` to let PHPStan know about its type.
* Replaces a check for the existence of the `stmts` property with checks for `ClassLike` and `Namespace_` entities. This helps PHPStan understand what to expect from `$node->stmts`. Only `ClassLike` and `Namespace_` need their children to be traversed.