### PR TITLE
Release phpdocumentor/reflection-docblock lock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "nikic/php-parser": "^4.13",
         "php-stubs/generator": "^0.8.3",
-        "phpdocumentor/reflection-docblock": "5.3",
+        "phpdocumentor/reflection-docblock": "^5.4.1",
         "phpstan/phpstan": "^1.10.49",
         "phpunit/phpunit": "^9.5",
         "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.11"

--- a/src/Visitor.php
+++ b/src/Visitor.php
@@ -35,7 +35,7 @@ use StubsGenerator\NodeVisitor;
 
 class Visitor extends NodeVisitor
 {
-    private \phpDocumentor\Reflection\DocBlockFactory $docBlockFactory;
+    private \phpDocumentor\Reflection\DocBlockFactoryInterface $docBlockFactory;
 
     /** @var array<string,array<int|string,string>> */
     private array $functionMap;


### PR DESCRIPTION
The [phpdocumentor/reflection-docblock](https://github.com/phpDocumentor/ReflectionDocBlock) was locked to version 5.3.0 in  #165 because version 5.4.0 caused many PHPStan tags to disappear. This was reported in [issue #365](https://github.com/phpDocumentor/ReflectionDocBlock/issues/365) and fixed in version [5.4.1](https://github.com/phpDocumentor/ReflectionDocBlock/releases/tag/5.4.1).