### PR TITLE
Support dynamic return type for `wp_debug_backtrace_summary`

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -118,6 +118,7 @@ return [
     'the_date' => ['($display is true ? void : string)'],
     'the_modified_date' => ['($display is true ? void : string)'],
     'the_title' => ['($display is true ? void : string|void)'],
+    'wp_debug_backtrace_summary' => ['($pretty is true ? string : list<string>)'],
     'wp_loginout' => ['($display is true ? void : string)'],
     'wp_register' => ['($display is true ? void : string)'],
     'wp_title' => ['($display is true ? void : string)'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -30,6 +30,7 @@ class TypeInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/is_wp_error.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql2date.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_debug_backtrace_summary.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_error_parameter.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_theme.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wpdb.php');

--- a/tests/data/wp_debug_backtrace_summary.php
+++ b/tests/data/wp_debug_backtrace_summary.php
@@ -9,4 +9,4 @@ use function PHPStan\Testing\assertType;
 
 assertType('string', wp_debug_backtrace_summary());
 assertType('string', wp_debug_backtrace_summary( null, 0, true ));
-assertType('array<int, string>', wp_debug_backtrace_summary( null, 0, false ));
+assertType('list<string>', wp_debug_backtrace_summary( null, 0, false ));

--- a/tests/data/wp_debug_backtrace_summary.php
+++ b/tests/data/wp_debug_backtrace_summary.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_debug_backtrace_summary;
+use function PHPStan\Testing\assertType;
+
+assertType('string', wp_debug_backtrace_summary());
+assertType('string', wp_debug_backtrace_summary( null, 0, true ));
+assertType('array<int, string>', wp_debug_backtrace_summary( null, 0, false ));


### PR DESCRIPTION
Function returns `string` by default but may also return `array` of `$pretty` is passed as `false`. 

https://developer.wordpress.org/reference/functions/wp_debug_backtrace_summary/
