### PR TITLE
Assign discoverable names to properties

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -21,6 +21,14 @@ $filesystemDirlistReturnType = "false|array<string, array{name: string, perms: s
  *
  * '<class_name>' => [null, '<arg_name>' => '<arg_type>']
  *
+ * For class methods:
+ *
+ * '<class_name::method_name>' => ['<return_type>', '<arg_name>' => '<arg_type>']
+ *
+ * For class properties:
+ *
+ * '<class_name::$property_name>' => [null, '@phpstan-var' => 'property_type>']
+ *
  * @link https://github.com/phpstan/phpstan-src/blob/1.10.x/resources/functionMap.php
  */
 return [

--- a/functionMap.php
+++ b/functionMap.php
@@ -27,7 +27,7 @@ $filesystemDirlistReturnType = "false|array<string, array{name: string, perms: s
  *
  * For class properties:
  *
- * '<class_name::$property_name>' => [null, '@phpstan-var' => 'property_type>']
+ * '<class_name::$property_name>' => [null, '@phpstan-var' => '<property_type>']
  *
  * @link https://github.com/phpstan/phpstan-src/blob/1.10.x/resources/functionMap.php
  */

--- a/src/Visitor.php
+++ b/src/Visitor.php
@@ -76,15 +76,16 @@ class Visitor extends NodeVisitor
 
         $symbolName = self::getNodeName($node);
 
-        if ($node instanceof ClassMethod) {
+        if ($node instanceof ClassMethod || $node instanceof Property) {
             $parent = $this->stack[count($this->stack) - 2];
             \assert($parent instanceof \PhpParser\Node\Stmt\ClassLike);
 
             if ($parent->name !== null) {
                 $symbolName = sprintf(
-                    '%1$s::%2$s',
+                    '%1$s::%2$s%3$s',
                     $parent->name->name,
-                    $node->name->name
+                    $node instanceof Property ? '$' : '',
+                    $symbolName
                 );
             }
         }
@@ -125,10 +126,7 @@ class Visitor extends NodeVisitor
         }
 
         if ($node instanceof Property) {
-            return sprintf(
-                'property_%s',
-                uniqid()
-            );
+            return $node->props[0]->name->name;
         }
 
         return '';


### PR DESCRIPTION
This PR assigns discoverable names to properties using the notation `ClassName::$property`. This allows us to use properties in the functionMap and extend the "type inheritance" feature of the visitor to properties.

Input format for the functionMap:
```php
[
    'ClassName::$property' => [null, '@phpstan-var' => 'array<string, string>'],
]
```
which will transform

```php
class ClassName {
    /**
     * @var array
     */
    public $property;
}
```
to
```php
class ClassName {
    /**
     * @var array
     * @phpstan-var array<string, string>
     */
    public $property;
}
```