### PR TITLE
Add/Fix test for unknown parameter in `WP_REST_Request::get_param()`

### DIFF
--- a/tests/data/wp_rest_request.php
+++ b/tests/data/wp_rest_request.php
@@ -18,11 +18,12 @@ $request = new WP_REST_Request();
 assertType('string', $request->get_param('stringParam'));
 assertType('int', $request->get_param('intParam'));
 assertType('bool', $request->get_param('boolParam'));
+assertType('null', $request->get_param('unknownParam'));
 
 assertType('string', $request['stringParam']);
 assertType('int', $request['intParam']);
 assertType('bool', $request['boolParam']);
-assertType('bool|int|string', $request['unknownParam']);
+assertType('null', $request['unknownParam']);
 
 assertType('array{stringParam: string, intParam: int, boolParam: bool}', $request->get_params());
 


### PR DESCRIPTION
`WP_REST_Request::get_param()` returns `null` when called with an unknown parameter.

Testing for this results in failed tests.

Related to #186.

cc @lipemat