### PR TITLE
Add @param-out for wp_parse_str()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -157,4 +157,5 @@ return [
     'WP_Widget::form' => [null, 'instance' => 'T'],
     'WP_Widget::update' => [null, 'new_instance' => 'T', 'old_instance' => 'T'],
     'WP_Widget::widget' => [null, 'instance' => 'T', 'args' => 'array{name:string,id:string,description:string,class:string,before_widget:string,after_widget:string,before_title:string,after_title:string,before_sidebar:string,after_sidebar:string,show_in_rest:boolean,widget_id:string,widget_name:string}'],
+    'wp_parse_str' => [null, '@param-out' => 'array<int|string, array|string>'],
 ];

--- a/functionMap.php
+++ b/functionMap.php
@@ -157,5 +157,5 @@ return [
     'WP_Widget::form' => [null, 'instance' => 'T'],
     'WP_Widget::update' => [null, 'new_instance' => 'T', 'old_instance' => 'T'],
     'WP_Widget::widget' => [null, 'instance' => 'T', 'args' => 'array{name:string,id:string,description:string,class:string,before_widget:string,after_widget:string,before_title:string,after_title:string,before_sidebar:string,after_sidebar:string,show_in_rest:boolean,widget_id:string,widget_name:string}'],
-    'wp_parse_str' => [null, '@param-out' => 'array<int|string, array|string>'],
+    'wp_parse_str' => [null, '@param-out' => 'array<int|string, array|string> $result'],
 ];


### PR DESCRIPTION
Currently, no tests have been added as PHPStan requires bleeding edge to be enabled in order not to discard the type provided via `@param-out`.

Assertions might look like
```php
// tests/data/wp_parse_str.php

declare(strict_types=1);

namespace PhpStubs\WordPress\Core\Tests;

use function wp_parse_str;
use function PHPStan\Testing\assertType;

// The type of `$result` cannot be narrowed further via stubs.
wp_parse_str('key=value');
assertType('array<int|string, array|string>', $result);
wp_parse_str('key1[key2]]=value');
assertType('array<int|string, array|string>', $result);
```