### PR TITLE
Add conditional return type for _wp_json_sanity_check()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -32,6 +32,7 @@ $filesystemDirlistReturnType = "false|array<string, array{name: string, perms: s
  * @link https://github.com/phpstan/phpstan-src/blob/1.10.x/resources/functionMap.php
  */
 return [
+    '_wp_json_sanity_check' => ['T', '@phpstan-template' => 'T', 'value' => 'T', 'depth' => 'positive-int'],
     '_get_list_table' => ["(\$class_name is 'WP_Posts_List_Table'|'WP_Media_List_Table'|'WP_Terms_List_Table'|'WP_Users_List_Table'|'WP_Comments_List_Table'|'WP_Post_Comments_List_Table'|'WP_Links_List_Table'|'WP_Plugin_Install_List_Table'|'WP_Themes_List_Table'|'WP_Theme_Install_List_Table'|'WP_Plugins_List_Table'|'WP_Application_Passwords_List_Table'|'WP_MS_Sites_List_Table'|'WP_MS_Users_List_Table'|'WP_MS_Themes_List_Table'|'WP_Privacy_Data_Export_Requests_List_Table'|'WP_Privacy_Data_Removal_Requests_List_Table' ? T : false)", '@phpstan-template' => 'T', 'class_name' => 'class-string<T>', 'args' => 'array{screen?: string}'],
     'addslashes_gpc' => ['T', '@phpstan-template' => 'T', 'gpc' => 'T'],
     'add_submenu_page' => [null, 'callback' => "''|callable"],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -10,6 +10,7 @@ class TypeInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
     public function dataFileAsserts(): iterable
     {
         yield from $this->gatherAssertTypes(__DIR__ . '/data/_get_list_table.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/_wp_json_sanity_check.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/current_time.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/echo_parameter.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_approved_comments.php');

--- a/tests/data/_wp_json_sanity_check.php
+++ b/tests/data/_wp_json_sanity_check.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use stdClass;
+
+use function PHPStan\Testing\assertType;
+use function _wp_json_sanity_check;
+
+assertType('null', _wp_json_sanity_check(null, 1));
+assertType('bool', _wp_json_sanity_check((bool)$_GET['value'], 1));
+assertType('int', _wp_json_sanity_check((int)$_GET['value'], 1));
+assertType('string', _wp_json_sanity_check((string)$_GET['value'], 1));
+assertType('array', _wp_json_sanity_check((array)$_GET['value'], 1));
+assertType('stdClass', _wp_json_sanity_check(new stdClass(), 1));
+assertType('mixed', _wp_json_sanity_check($_GET['value'], 1));


### PR DESCRIPTION
I'm not sure if we provide stubs for "private" functions. Since we include them, it might make sense to improve the type accuracy.