### PR TITLE
Add cond. return type and param type for absint()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -34,6 +34,7 @@ $filesystemDirlistReturnType = "false|array<string, array{name: string, perms: s
 return [
     '_wp_json_sanity_check' => ['T', '@phpstan-template' => 'T', 'value' => 'T', 'depth' => 'positive-int'],
     '_get_list_table' => ["(\$class_name is 'WP_Posts_List_Table'|'WP_Media_List_Table'|'WP_Terms_List_Table'|'WP_Users_List_Table'|'WP_Comments_List_Table'|'WP_Post_Comments_List_Table'|'WP_Links_List_Table'|'WP_Plugin_Install_List_Table'|'WP_Themes_List_Table'|'WP_Theme_Install_List_Table'|'WP_Plugins_List_Table'|'WP_Application_Passwords_List_Table'|'WP_MS_Sites_List_Table'|'WP_MS_Users_List_Table'|'WP_MS_Themes_List_Table'|'WP_Privacy_Data_Export_Requests_List_Table'|'WP_Privacy_Data_Removal_Requests_List_Table' ? T : false)", '@phpstan-template' => 'T', 'class_name' => 'class-string<T>', 'args' => 'array{screen?: string}'],
+    'absint' => ['($maybeint is T&non-negative-int ? T : ($maybeint is negative-int ? positive-int : ($maybeint is empty ? 0 : ($maybeint is numeric-string ? non-negative-int : ($maybeint is string ? 0 : ($maybeint is true|non-empty-array ? 1 : ($maybeint is bool ? 0|1 : non-negative-int)))))))', '@template T' => 'of int', 'maybeint' => 'T|scalar|array|resource|null'],
     'addslashes_gpc' => ['T', '@phpstan-template' => 'T', 'gpc' => 'T'],
     'add_submenu_page' => [null, 'callback' => "''|callable"],
     'have_posts' => [null, '@phpstan-impure' => ''],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -11,6 +11,7 @@ class TypeInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
     {
         yield from $this->gatherAssertTypes(__DIR__ . '/data/_get_list_table.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/_wp_json_sanity_check.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/absint.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/current_time.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/echo_parameter.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_approved_comments.php');

--- a/tests/data/absint.php
+++ b/tests/data/absint.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use stdClass;
+
+use function absint;
+use function PHPStan\Testing\assertType;
+
+/** @var int<1, max> $posInt */
+$posInt = $_GET['posInt'];
+
+/** @var int<0, max> $nonNegInt */
+$nonNegInt = $_GET['nonNegInt'];
+
+/** @var resource $resource */
+$resource = $_GET['resource'];
+
+// Returns input for non-negative integers
+assertType('0', absint(0));
+assertType('1', absint(1));
+assertType('10', absint(10));
+assertType('int<1, max>', absint($posInt));
+assertType('int<0, max>', absint($nonNegInt));
+
+// Returns 0 for "empty" input
+assertType('0', absint(null));
+assertType('0', absint(false));
+assertType('0', absint(0.0));
+assertType('0', absint(''));
+assertType('0', absint([]));
+// and non-numeric string
+assertType('0', absint('nonNumericString'));
+assertType('0', absint(' '));
+
+// Returns 1 for true and non-empty array
+assertType('1', absint(true));
+assertType('1', absint(['key' => 'value']));
+
+// Returns 0 or 1 for booleans
+assertType('0|1', absint((bool)$_GET['bool']));
+
+// Returns positive integer for strictly negative integer input
+assertType('int<1, max>', absint(-1));
+assertType('int<1, max>', absint(-10));
+
+// Returns non-negative integer for floats, numeric strings, ressources
+assertType('int<0, max>', absint(1.0));
+assertType('int<0, max>', absint('-10'));
+assertType('int<0, max>', absint($resource));
+// and any other type that is not a subtype of `$maybeint`
+assertType('int<0, max>', absint(new stdClass()));


### PR DESCRIPTION
For constant values other than non-negative integers and arrays, a dynamic return type extension is needed. I.e. for constant positive and negative floats, as well as for constant positive and negative numeric strings.