### PR TITLE
Add dynamic return type for stripslashes_from_strings_only

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -49,6 +49,7 @@ return [
     'sanitize_post' => ['T', '@phpstan-template' => 'T of array|object', 'post' => 'T'],
     'sanitize_term' => ['T', '@phpstan-template' => 'T of array|object', 'term' => 'T'],
     'stripslashes_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
+    'stripslashes_from_strings_only' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'urldecode_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'urlencode_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'validate_file' => ["(\$file is '' ? 0 : (\$allowed_files is empty ? 0|1|2 : 0|1|2|3))"],

--- a/tests/Faker.php
+++ b/tests/Faker.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+/**
+ * @phpstan-type Types array{
+ *   bool: bool,
+ *   int: int,
+ *   float: float,
+ *   string: string,
+ *   array: array<mixed>,
+ *   resource: resource,
+ *   object: object,
+ *   numeric-string: numeric-string,
+ *   null: null,
+ *   mixed: mixed,
+ *   true: true,
+ *   false: false,
+ *   callable: callable,
+ *   iterable: iterable<mixed>,
+ *   array-key: array-key,
+ *   positive-int: positive-int,
+ *   negative-int: negative-int,
+ *   non-positive-int: non-positive-int,
+ *   non-negative-int: non-negative-int,
+ *   non-zero-int: non-zero-int,
+ * }
+ */
+class Faker
+{
+    /**
+     * @var Types $types
+     * @phpstan-ignore-next-line
+     */
+    private static $types;
+
+    /**
+     * @template T of string
+     * @param T $type
+     * @return Types[T]
+     */
+    public static function fake(string $type): mixed
+    {
+        return self::$types[$type];
+    }
+
+    /**
+     * @template T of string
+     * @template K of string
+     * @param T $valueType
+     * @param K $keyType
+     * @return array<Types[K], Types[T]>
+     */
+    public static function fakeArray(string $valueType, string $keyType = 'array-key'): mixed
+    {
+        return [$_GET[$keyType], $_GET[$valueType]];
+    }
+
+    /**
+     * @template T of non-empty-array<key-of<Types>>
+     * @param T $types
+     * @return Types[value-of<T>]
+     */
+    public static function or(array $types): mixed
+    {
+        foreach ($types as $type) {
+            if ($_GET['thing'] === $type) {
+                return self::fake($type);
+            }
+        }
+        return self::fake($types[0]);
+    }
+}

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -44,6 +44,7 @@ class TypeInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/paginate_links.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/rest_ensure_response.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/size_format.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/stripslashes.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/validate_file.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_debug_backtrace_summary.php');

--- a/tests/data/stripslashes.php
+++ b/tests/data/stripslashes.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function PHPStan\Testing\assertType;
+use function stripslashes_deep;
+use function stripslashes_from_strings_only;
+
+assertType('null', stripslashes_deep(null));
+assertType('bool', stripslashes_deep(Faker::fake('bool')));
+assertType('int', stripslashes_deep(Faker::fake('int')));
+assertType('float', stripslashes_deep(Faker::fake('float')));
+assertType('string', stripslashes_deep(Faker::fake('string')));
+assertType('array', stripslashes_deep(Faker::fake('array')));
+assertType('resource', stripslashes_deep(Faker::fake('resource')));
+assertType('object', stripslashes_deep(Faker::fake('object')));
+
+assertType('null', stripslashes_from_strings_only(null));
+assertType('bool', stripslashes_from_strings_only(Faker::fake('bool')));
+assertType('int', stripslashes_from_strings_only(Faker::fake('int')));
+assertType('float', stripslashes_from_strings_only(Faker::fake('float')));
+assertType('string', stripslashes_from_strings_only(Faker::fake('string')));
+assertType('array', stripslashes_from_strings_only(Faker::fake('array')));
+assertType('resource', stripslashes_from_strings_only(Faker::fake('resource')));
+assertType('object', stripslashes_from_strings_only(Faker::fake('object')));


### PR DESCRIPTION
This PR also adds a class, `Faker`. This is a helper class for tests to "fake" types. Instead of `$string_ = (string)$_GET['string']`, one can simply use `Faker::type('string')`. This is particularly useful for types that cannot be cast. For example: 

```php
/** @var numeric-string $numericString */
$numericString = $_GET['numericString'];
```

can be simplified to `Faker::type('numeric-string')` as well. @szepeviktor, if you dislike this idea, I’ll revert to the traditional method. Otherwise, I would update all the other tests to use this class. Also, I’m flexible regarding the class name or method names. If there are other preferences, we can rename them.

If we exclude the file from PHPStan analysis, we could even omit the method statements, as the type faking is handled through the docBlock. A new type can be introduced via the `@phpstan-type Types`.