### PR TITLE
Update name of disabled phpcs rule

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpStubs\WordPress\Core\Tests;
 
-// phpcs:disable Squiz.PHP.DiscouragedFunctions
+// phpcs:disable Generic.PHP.ForbiddenFunctions.Found
 define('OBJECT', 'OBJECT');
 define('ARRAY_A', 'ARRAY_A');
 define('ARRAY_N', 'ARRAY_N');


### PR DESCRIPTION
Underlying standard switched from Squiz.PHP.DiscouragedFunctions to Generic.PHP.ForbiddenFunctions. https://github.com/szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset/pull/15/