### PR TITLE
Improve removal of unused comments

### DIFF
--- a/src/Visitor.php
+++ b/src/Visitor.php
@@ -879,28 +879,26 @@ class Visitor extends NodeVisitor
             return $node;
         }
 
-        // Remove "//" comments.
         $comments = [];
         foreach ($node->getComments() as $comment) {
-            if (strpos(trim($comment->getText()), '//') === 0) {
+            $commentText = trim($comment->getText());
+
+            // Strip out comments that are not doc comments.
+            if (
+                strpos($commentText, '/**') === false
+            ) {
                 continue;
             }
+
+            // Strip out comments that are not templates and not the actual docComment.
+            if (
+                strpos($commentText, '/**#@') === false
+                && $commentText !== trim((string)$node->getDocComment())
+            ) {
+                continue;
+            }
+
             $comments[] = $comment;
-        }
-
-        $node->setAttribute('comments', $comments);
-
-        if ($node->getDocComment() === null) {
-            return $node;
-        }
-
-        // Remove file comments that are bound to the first node in a file.
-        $comments = $node->getComments();
-        if (
-            $comments[0]->getText() !== (string)$node->getDocComment()
-            && strpos($comments[0]->getText(), '/**#@') !== 0
-        ) {
-            array_shift($comments);
         }
 
         $node->setAttribute('comments', $comments);

--- a/src/Visitor.php
+++ b/src/Visitor.php
@@ -883,7 +883,7 @@ class Visitor extends NodeVisitor
         foreach ($node->getComments() as $comment) {
             $commentText = trim($comment->getText());
 
-            // Strip out comments that are not doc comments.
+            // Strip out comments that are not PHPDoc comments.
             if (
                 strpos($commentText, '/**') === false
             ) {


### PR DESCRIPTION
Improves removal of unused comments by stripping out all comments that do not start with `/**`.