### PR TITLE
Fix wp_get_archives

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -59,7 +59,7 @@ return [
     'wp_generate_tag_cloud' => ["(\$args is array{format: 'array'} ? array<int, string> : string)"],
     'wp_get_schedule' => [null, 'args' => $cronArgsType],
     'wp_get_scheduled_event' => [null, 'args' => $cronArgsType],
-    'wp_get_archives' => ['($args is array{echo: false|0} ? string : void)'],
+    'wp_get_archives' => ['($args is array{echo: false|0} ? string|void : void)'],
     'WP_Http::get' => [$httpReturnType],
     'WP_Http::head' => [$httpReturnType],
     'WP_Http::post' => [$httpReturnType],

--- a/tests/data/wp_get_archives.php
+++ b/tests/data/wp_get_archives.php
@@ -23,8 +23,8 @@ assertType('null', wp_get_archives(['echo' => true, 'key' => 'value']));
 assertType('null', wp_get_archives(['echo' => 1, 'key' => 'value']));
 
 // Explicit value of false|0
-assertType('string', wp_get_archives(['echo' => false, 'key' => 'value']));
-assertType('string', wp_get_archives(['echo' => 0, 'key' => 'value']));
+assertType('string|null', wp_get_archives(['echo' => false, 'key' => 'value']));
+assertType('string|null', wp_get_archives(['echo' => 0, 'key' => 'value']));
 
 // Unknown value
 assertType('string|null', wp_get_archives(['echo' => Faker::bool(), 'key' => 'value']));


### PR DESCRIPTION
Returns void even if echo is false

See line [2019 in wp-includes/general-template.php](https://github.com/WordPress/WordPress/blob/70bfe13aa0a9ef7429c226745ca87060ac9c6aca/wp-includes/general-template.php#L2019)

https://github.com/szepeviktor/phpstan-wordpress/pull/243

