### PR TITLE
Fix: Remove WP_Error from get_term_by return type

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -136,7 +136,7 @@ return [
     'get_post_stati' => ["(\$output is 'names' ? array<string, string> : array<string, \stdClass>)"],
     'get_comment' => ["(\$comment is \WP_Comment ? array<array-key, mixed>|\WP_Comment : array<array-key, mixed>|\WP_Comment|null) & (\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Comment|null))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'"],
     'get_post' => ["(\$post is \WP_Post ? array<array-key, mixed>|\WP_Post : array<array-key, mixed>|\WP_Post|null) & (\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'" ],
-    'get_term_by' => ["(\$output is 'ARRAY_A' ? array<string, string|int>|\WP_Error|false : (\$output is 'ARRAY_N' ? list<string|int>|\WP_Error|false : \WP_Term|\WP_Error|false))"],
+    'get_term_by' => ["false|(\$output is 'ARRAY_A' ? array<string, string|int> : (\$output is 'ARRAY_N' ? list<string|int> : \WP_Term))"],
     'get_page_by_path' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],
     'get_term' => ["(\$output is 'ARRAY_A' ? array<string, string|int>|\WP_Error|null : (\$output is 'ARRAY_N' ? list<string|int>|\WP_Error|null : \WP_Term|\WP_Error|null))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'"],
     'has_action' => ['($callback is false ? bool : false|int)'],

--- a/tests/data/get_term_by.php
+++ b/tests/data/get_term_by.php
@@ -7,7 +7,7 @@ namespace PhpStubs\WordPress\Core\Tests;
 use function get_term_by;
 use function PHPStan\Testing\assertType;
 
-assertType('WP_Error|WP_Term|false', get_term_by('term_id', 2, '', OBJECT));
-assertType('WP_Error|WP_Term|false', get_term_by('slug', 'test'));
-assertType('array<string, int|string>|WP_Error|false', get_term_by('term_id', 2, '', ARRAY_A));
-assertType('list<int|string>|WP_Error|false', get_term_by('term_id', 2, '', ARRAY_N));
+assertType('WP_Term|false', get_term_by('term_id', Faker::int(), '', OBJECT));
+assertType('WP_Term|false', get_term_by('slug', 'test'));
+assertType('array<string, int|string>|false', get_term_by('term_id', Faker::int(), '', ARRAY_A));
+assertType('list<int|string>|false', get_term_by('term_id', Faker::int(), '', ARRAY_N));


### PR DESCRIPTION
`get_term_by` calls `get_terms` and `get_term`, both of which can return a `WP_Error` object if the taxonomy specified in `$args['taxonomy']` (corresponding to the `$taxonomy` parameter of `get_term_by`) does not exist. However, `get_term_by` handles any potential errors from `get_term` and `get_terms` by converting them into a `false` return value, thereby ensuring it never directly returns a `WP_Error` object.

Removing `WP_Error` from the return type of `get_term_by` reflects the actual behaviour of the function.

Closes #284