### PR TITLE
Narrow return type of wp_extract_urls

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -232,4 +232,5 @@ return [
     'wp_nonce_field' => [null, 'action' => '-1|string'],
     'did_action' => ['int<0, max>'],
     'get_current_blog_id' => ['int<0, max>'],
+    'wp_extract_urls' => ['($content is empty ? array{} : list<string>)'],
 ];

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -57,6 +57,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_die.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_dropdown_languages.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_error_parameter.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_extract_urls.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_generate_tag_cloud.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_archives.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_post_categories.php');

--- a/tests/data/wp_extract_urls.php
+++ b/tests/data/wp_extract_urls.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_extract_urls;
+use function PHPStan\Testing\assertType;
+
+assertType('array{}', wp_extract_urls(''));
+
+assertType('list<string>', wp_extract_urls('content with no URLs'));
+assertType('list<string>', wp_extract_urls('content with one URL: https://example.com'));
+assertType('list<string>', wp_extract_urls('content with multiple URLs: https://example.com and http://another-example.com'));
+
+assertType('list<string>', wp_extract_urls(Faker::string()));


### PR DESCRIPTION
Narrows the return type of `wp_extract_urls()` from `string[]` to `array{}|list<string>`. Does not handle the number of found urls in non empty `$content` strings.