### PR TITLE
Use Faker for unions in type inference

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,4 +15,4 @@ parameters:
         -
             path: tests/Faker.php
             identifier: class.notFound
-            count: 8
+            count: 9

--- a/tests/Faker.php
+++ b/tests/Faker.php
@@ -33,6 +33,7 @@ namespace PhpStubs\WordPress\Core\Tests;
  * @method static \WP_Translations wpTranslations()
  * @method static \WP_Query wpQuery()
  * @method static \WP_Widget_Factory wpWidgetFactory()
+ * @method static \wpdb wpdb()
  */
 class Faker
 {

--- a/tests/data/Faker.php
+++ b/tests/data/Faker.php
@@ -47,8 +47,13 @@ assertType('array<int|string>', Faker::union(Faker::array(Faker::int()), Faker::
 assertType('array<mixed>', Faker::union(Faker::array(), Faker::strArray()));
 assertType('array<mixed>', Faker::union(Faker::array(), Faker::intArray()));
 assertType('string|null', Faker::union(Faker::string(), null));
+assertType("'bar'|'foo'", Faker::union('foo', 'bar'));
+assertType('string', Faker::union('foo', Faker::string()));
+assertType("'foo'|int", Faker::union('foo', Faker::int()));
+assertType("array{'baz'}|array{foo: 'bar'}", Faker::union(['foo' => 'bar'], ['baz']));
 
 // Other
+assertType('callable(): mixed', Faker::callable());
 assertType('resource', Faker::resource());
 assertType('object', Faker::object());
 assertType('stdClass', Faker::stdClass());
@@ -60,4 +65,5 @@ assertType('WP_Theme', Faker::wpTheme());
 assertType('WP_Translations', Faker::wpTranslations());
 assertType('WP_Query', Faker::wpQuery());
 assertType('WP_Widget_Factory', Faker::wpWidgetFactory());
+assertType('wpdb', Faker::wpdb());
 assertType('mixed', Faker::mixed());

--- a/tests/data/_get_list_table.php
+++ b/tests/data/_get_list_table.php
@@ -35,16 +35,16 @@ assertType('WP_Privacy_Data_Export_Requests_List_Table', _get_list_table('WP_Pri
 assertType('WP_Privacy_Data_Removal_Requests_List_Table', _get_list_table('WP_Privacy_Data_Removal_Requests_List_Table'));
 
 // Union of core WP_List_Table classes
-assertType('WP_Media_List_Table|WP_Posts_List_Table', _get_list_table(isset($_GET['foo']) ? 'WP_Posts_List_Table' : 'WP_Media_List_Table'));
+assertType('WP_Media_List_Table|WP_Posts_List_Table', _get_list_table(Faker::union('WP_Posts_List_Table', 'WP_Media_List_Table')));
 
 // Union of core WP_List_Table class and class that is not a subclass of WP_List_Table
-assertType('WP_Posts_List_Table|false', _get_list_table(isset($_GET['foo']) ? 'WP_Posts_List_Table' : 'WP_Post'));
+assertType('WP_Posts_List_Table|false', _get_list_table(Faker::union('WP_Posts_List_Table', 'WP_Post')));
 
 // WP_Post_Comments_List_Table is generalized WP_Comments_List_Table
-assertType('WP_Comments_List_Table', _get_list_table(isset($_GET['foo']) ? 'WP_Comments_List_Table' : 'WP_Post_Comments_List_Table'));
+assertType('WP_Comments_List_Table', _get_list_table(Faker::union('WP_Comments_List_Table', 'WP_Post_Comments_List_Table')));
 
 // WP_Theme_Install_List_Table is generalized to WP_Themes_List_Table
-assertType('WP_Themes_List_Table', _get_list_table(isset($_GET['foo']) ? 'WP_Themes_List_Table' : 'WP_Theme_Install_List_Table'));
+assertType('WP_Themes_List_Table', _get_list_table(Faker::union('WP_Themes_List_Table', 'WP_Theme_Install_List_Table')));
 
 // Unknown string
 assertType('WP_Application_Passwords_List_Table|WP_Comments_List_Table|WP_Links_List_Table|WP_Media_List_Table|WP_MS_Sites_List_Table|WP_MS_Themes_List_Table|WP_MS_Users_List_Table|WP_Plugin_Install_List_Table|WP_Plugins_List_Table|WP_Posts_List_Table|WP_Privacy_Data_Export_Requests_List_Table|WP_Privacy_Data_Removal_Requests_List_Table|WP_Terms_List_Table|WP_Themes_List_Table|WP_Users_List_Table|false', _get_list_table(Faker::string()));

--- a/tests/data/get_attachment_taxonomies.php
+++ b/tests/data/get_attachment_taxonomies.php
@@ -21,6 +21,6 @@ assertType('array<string, WP_Taxonomy>', get_attachment_taxonomies(Faker::int(),
 assertType('array<int|string, string|WP_Taxonomy>', get_attachment_taxonomies(Faker::int(), Faker::string()));
 
 // Unions
-assertType('array<int|string, string|WP_Taxonomy>', get_attachment_taxonomies(Faker::int(), Faker::bool() ? 'names' : 'objects'));
-assertType('array<int|string, string|WP_Taxonomy>', get_attachment_taxonomies(Faker::int(), Faker::bool() ? Faker::string() : 'names'));
-assertType('array<int|string, string|WP_Taxonomy>', get_attachment_taxonomies(Faker::int(), Faker::bool() ? Faker::string() : 'objects'));
+assertType('array<int|string, string|WP_Taxonomy>', get_attachment_taxonomies(Faker::int(), Faker::union('names', 'objects')));
+assertType('array<int|string, string|WP_Taxonomy>', get_attachment_taxonomies(Faker::int(), Faker::union(Faker::string(), 'names')));
+assertType('array<int|string, string|WP_Taxonomy>', get_attachment_taxonomies(Faker::int(), Faker::union(Faker::string(), 'objects')));

--- a/tests/data/get_object_taxonomies.php
+++ b/tests/data/get_object_taxonomies.php
@@ -21,6 +21,6 @@ assertType('array<string, WP_Taxonomy>', get_object_taxonomies('post', 'Hello'))
 assertType('array<int|string, string|WP_Taxonomy>', get_object_taxonomies('post', Faker::string()));
 
 // Unions
-assertType('array<int|string, string|WP_Taxonomy>', get_object_taxonomies('post', Faker::bool() ? 'names' : 'objects'));
-assertType('array<int|string, string|WP_Taxonomy>', get_object_taxonomies('post', Faker::bool() ? Faker::string() : 'names'));
-assertType('array<int|string, string|WP_Taxonomy>', get_object_taxonomies('post', Faker::bool() ? Faker::string() : 'objects'));
+assertType('array<int|string, string|WP_Taxonomy>', get_object_taxonomies('post', Faker::union('names', 'objects')));
+assertType('array<int|string, string|WP_Taxonomy>', get_object_taxonomies('post', Faker::union(Faker::string(), 'names')));
+assertType('array<int|string, string|WP_Taxonomy>', get_object_taxonomies('post', Faker::union(Faker::string(), 'objects')));

--- a/tests/data/get_post_stati.php
+++ b/tests/data/get_post_stati.php
@@ -22,6 +22,6 @@ assertType('array<string, stdClass>', get_post_stati([], 'Hello'));
 assertType('array<string, stdClass|string>', get_post_stati([], Faker::string()));
 
 // Unions
-assertType('array<string, stdClass|string>', get_post_stati([], Faker::bool() ? 'names' : 'objects'));
-assertType('array<string, stdClass|string>', get_post_stati([], Faker::bool() ? Faker::string() : 'names'));
-assertType('array<string, stdClass|string>', get_post_stati([], Faker::bool() ? Faker::string() : 'objects'));
+assertType('array<string, stdClass|string>', get_post_stati([], Faker::union('names', 'objects')));
+assertType('array<string, stdClass|string>', get_post_stati([], Faker::union(Faker::string(), 'names')));
+assertType('array<string, stdClass|string>', get_post_stati([], Faker::union(Faker::string(), 'objects')));

--- a/tests/data/get_posts.php
+++ b/tests/data/get_posts.php
@@ -18,50 +18,50 @@ assertType('array<int, WP_Post>', get_posts(['fields' => 'Hello']));
 assertType('array<int, int|WP_Post>', get_posts(Faker::array()));
 
 // Unions
-$union = Faker::bool() ? ['key' => 'value'] : ['some' => 'thing'];
+$union = Faker::union(['key' => 'value'], ['some' => 'thing']);
 assertType('array<int, WP_Post>', get_posts($union));
 
-$union = Faker::bool() ? ['key' => 'value'] : ['fields' => 'ids'];
+$union = Faker::union(['key' => 'value'], ['fields' => 'ids']);
 assertType('array<int, int|WP_Post>', get_posts($union));
 
-$union = Faker::bool() ? ['key' => 'value'] : ['fields' => ''];
+$union = Faker::union(['key' => 'value'], ['fields' => '']);
 assertType('array<int, WP_Post>', get_posts($union));
 
-$union = Faker::bool() ? ['key' => 'value'] : ['fields' => 'id=>parent'];
+$union = Faker::union(['key' => 'value'], ['fields' => 'id=>parent']);
 assertType('array<int, int|WP_Post>', get_posts($union));
 
-$union = Faker::bool() ? ['fields' => ''] : ['fields' => 'ids'];
+$union = Faker::union(['fields' => ''], ['fields' => 'ids']);
 assertType('array<int, int|WP_Post>', get_posts($union));
 
-$union = Faker::bool() ? ['fields' => ''] : ['fields' => 'id=>parent'];
+$union = Faker::union(['fields' => ''], ['fields' => 'id=>parent']);
 assertType('array<int, int|WP_Post>', get_posts($union));
 
-$union = Faker::bool() ? ['fields' => 'ids'] : ['fields' => 'id=>parent'];
+$union = Faker::union(['fields' => 'ids'], ['fields' => 'id=>parent']);
 assertType('array<int, int>', get_posts($union));
 
-$union = Faker::bool() ? Faker::array() : ['fields' => ''];
+$union = Faker::union(Faker::array(), ['fields' => '']);
 assertType('array<int, int|WP_Post>', get_posts($union));
 
-$union = Faker::bool() ? Faker::array() : ['fields' => 'ids'];
+$union = Faker::union(Faker::array(), ['fields' => 'ids']);
 assertType('array<int, int|WP_Post>', get_posts($union));
 
-$union = Faker::bool() ? Faker::array() : ['fields' => 'id=>parent'];
+$union = Faker::union(Faker::array(), ['fields' => 'id=>parent']);
 assertType('array<int, int|WP_Post>', get_posts($union));
 
-$union = Faker::bool() ? Faker::string() : '';
+$union = Faker::union(Faker::string(), '');
 assertType('array<int, int|WP_Post>', get_posts(['fields' => $union]));
 
-$union = Faker::bool() ? Faker::string() : 'ids';
+$union = Faker::union(Faker::string(), 'ids');
 assertType('array<int, int|WP_Post>', get_posts(['fields' => $union]));
 
-$union = Faker::bool() ? Faker::string() : 'id=>parent';
+$union = Faker::union(Faker::string(), 'id=>parent');
 assertType('array<int, int|WP_Post>', get_posts(['fields' => $union]));
 
-$union = Faker::bool() ? Faker::string() : 'fields';
+$union = Faker::union(Faker::string(), 'fields');
 assertType('array<int, WP_Post>', get_posts([$union => '']));
 
-$union = Faker::bool() ? Faker::string() : 'fields';
+$union = Faker::union(Faker::string(), 'fields');
 assertType('array<int, int|WP_Post>', get_posts([$union => 'ids']));
 
-$union = Faker::bool() ? Faker::string() : 'fields';
+$union = Faker::union(Faker::string(), 'fields');
 assertType('array<int, int|WP_Post>', get_posts([$union => 'id=>parent']));

--- a/tests/data/get_taxonomies_for_attachments.php
+++ b/tests/data/get_taxonomies_for_attachments.php
@@ -21,6 +21,6 @@ assertType('array<string, WP_Taxonomy>', get_taxonomies_for_attachments('Hello')
 assertType('array<int|string, string|WP_Taxonomy>', get_taxonomies_for_attachments(Faker::string()));
 
 // Unions
-assertType('array<int|string, string|WP_Taxonomy>', get_taxonomies_for_attachments(Faker::bool() ? 'names' : 'objects'));
-assertType('array<int|string, string|WP_Taxonomy>', get_taxonomies_for_attachments(Faker::bool() ? Faker::string() : 'names'));
-assertType('array<int|string, string|WP_Taxonomy>', get_taxonomies_for_attachments(Faker::bool() ? Faker::string() : 'objects'));
+assertType('array<int|string, string|WP_Taxonomy>', get_taxonomies_for_attachments(Faker::union('names', 'objects')));
+assertType('array<int|string, string|WP_Taxonomy>', get_taxonomies_for_attachments(Faker::union(Faker::string(), 'names')));
+assertType('array<int|string, string|WP_Taxonomy>', get_taxonomies_for_attachments(Faker::union(Faker::string(), 'objects')));

--- a/tests/data/term_exists.php
+++ b/tests/data/term_exists.php
@@ -8,38 +8,49 @@ use function term_exists;
 use function tag_exists;
 use function PHPStan\Testing\assertType;
 
-$term = $_GET['term'] ?? 123;
-$taxo = $_GET['taxo'] ?? 'category';
+$termStr = Faker::string();
+$termInt = Faker::int();
+$termIntStr = Faker::union(Faker::int(), Faker::string());
 
 // Empty taxonomy
 assertType('string|null', term_exists(123));
 assertType('string|null', term_exists(123, ''));
-assertType('0|string|null', term_exists($term));
-assertType('0|string|null', term_exists($term, ''));
+assertType('string|null', term_exists($termStr));
+assertType('string|null', term_exists($termStr, ''));
+assertType('0|string|null', term_exists($termInt));
+assertType('0|string|null', term_exists($termInt, ''));
+assertType('0|string|null', term_exists($termIntStr));
+assertType('0|string|null', term_exists($termIntStr, ''));
 
 // Fixed taxonomy string
 assertType('array{term_id: string, term_taxonomy_id: string}|null', term_exists(123, 'category'));
-assertType('0|array{term_id: string, term_taxonomy_id: string}|null', term_exists($term, 'category'));
+assertType('array{term_id: string, term_taxonomy_id: string}|null', term_exists($termStr, 'category'));
+assertType('0|array{term_id: string, term_taxonomy_id: string}|null', term_exists($termInt, 'category'));
+assertType('0|array{term_id: string, term_taxonomy_id: string}|null', term_exists($termIntStr, 'category'));
 
 // Unknown taxonomy type
-assertType('array{term_id: string, term_taxonomy_id: string}|string|null', term_exists(123, $taxo));
-assertType('0|array{term_id: string, term_taxonomy_id: string}|string|null', term_exists($term, $taxo));
-assertType('null', term_exists('', $taxo));
+$taxonomy = (string)$_GET['taxonomy'] ?? '';
+assertType('array{term_id: string, term_taxonomy_id: string}|string|null', term_exists(123, Faker::string()));
+assertType('array{term_id: string, term_taxonomy_id: string}|string|null', term_exists($termStr, $taxonomy));
+assertType('0|array{term_id: string, term_taxonomy_id: string}|string|null', term_exists($termInt, Faker::string()));
+assertType('0|array{term_id: string, term_taxonomy_id: string}|string|null', term_exists($termIntStr, Faker::string()));
 
 // Term 0
 assertType('0', term_exists(0));
 assertType('0', term_exists(0, ''));
 assertType('0', term_exists(0, 'category'));
-assertType('0', term_exists(0, $taxo));
+assertType('0', term_exists(0, Faker::string()));
 
 // Term empty string
 assertType('null', term_exists(''));
 assertType('null', term_exists('', ''));
 assertType('null', term_exists('', 'category'));
-assertType('null', term_exists('', $taxo));
+assertType('null', term_exists('', Faker::string()));
 
 // tag_exists()
-assertType('array{term_id: string, term_taxonomy_id: string}|null', tag_exists(123));
-assertType('0|array{term_id: string, term_taxonomy_id: string}|null', tag_exists($term));
 assertType('0', tag_exists(0));
 assertType('null', tag_exists(''));
+assertType('array{term_id: string, term_taxonomy_id: string}|null', tag_exists(123));
+assertType('array{term_id: string, term_taxonomy_id: string}|null', tag_exists($termStr));
+assertType('0|array{term_id: string, term_taxonomy_id: string}|null', tag_exists($termInt));
+assertType('0|array{term_id: string, term_taxonomy_id: string}|null', tag_exists($termIntStr));

--- a/tests/data/wp_dropdown_languages.php
+++ b/tests/data/wp_dropdown_languages.php
@@ -15,9 +15,7 @@ namespace PhpStubs\WordPress\Core\Tests;
 use function wp_dropdown_languages;
 use function PHPStan\Testing\assertType;
 
-/** @var ''|null $emptyStringOrNull */
-$emptyStringOrNull = $_GET['emptyStringOrNull'];
-
+$emptyStringOrNull = Faker::union('', null);
 $stringOrNull = Faker::union(Faker::string(), null);
 
 // Default value

--- a/tests/data/wpdb.php
+++ b/tests/data/wpdb.php
@@ -4,18 +4,19 @@ declare(strict_types=1);
 
 namespace PhpStubs\WordPress\Core\Tests;
 
-use wpdb;
 use function PHPStan\Testing\assertType;
 
-// wpdb::get_row()
-assertType('stdClass|null', wpdb::get_row());
-assertType('stdClass|null', wpdb::get_row(null, 'OBJECT'));
-assertType('array<mixed>|null', wpdb::get_row(null, 'ARRAY_A'));
-assertType('list<mixed>|null', wpdb::get_row(null, 'ARRAY_N'));
+$wpdb = Faker::wpdb();
 
-// wpdb::get_results()
-assertType('list<array<mixed>>|null', wpdb::get_results(null, 'ARRAY_A'));
-assertType('list<array<int, mixed>>|null', wpdb::get_results(null, 'ARRAY_N'));
-assertType('list<stdClass>|null', wpdb::get_results());
-assertType('list<stdClass>|null', wpdb::get_results(null, 'OBJECT'));
-assertType('array<stdClass>|null', wpdb::get_results(null, 'OBJECT_K'));
+// $wpdb->get_row()
+assertType('stdClass|null', $wpdb->get_row());
+assertType('stdClass|null', $wpdb->get_row(null, 'OBJECT'));
+assertType('array<mixed>|null', $wpdb->get_row(null, 'ARRAY_A'));
+assertType('list<mixed>|null', $wpdb->get_row(null, 'ARRAY_N'));
+
+// $wpdb->get_results()
+assertType('list<array<mixed>>|null', $wpdb->get_results(null, 'ARRAY_A'));
+assertType('list<array<int, mixed>>|null', $wpdb->get_results(null, 'ARRAY_N'));
+assertType('list<stdClass>|null', $wpdb->get_results());
+assertType('list<stdClass>|null', $wpdb->get_results(null, 'OBJECT'));
+assertType('array<stdClass>|null', $wpdb->get_results(null, 'OBJECT_K'));


### PR DESCRIPTION
This PR uses the `Faker` class for type inference involving constant types in unions and adds several type assertions. While previously not working, constant types in unions can now be used.