### PR TITLE
Prefix template tag

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -141,7 +141,7 @@ return [
     'wp_insert_category' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_insert_link' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_insert_post' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
-    'wp_is_numeric_array' => ['(T is array ? (key-of<T> is int ? true : false) : false)', '@template' => 'T of mixed', 'data' => 'T', '@phpstan-assert-if-true' => '(T is list ? T : array<int, value-of<T>>) $data'],
+    'wp_is_numeric_array' => ['(T is array ? (key-of<T> is int ? true : false) : false)', '@phpstan-template' => 'T of mixed', 'data' => 'T', '@phpstan-assert-if-true' => '(T is list ? T : array<int, value-of<T>>) $data'],
     'wp_json_encode' => ['non-empty-string|false', 'depth' => 'int<1, max>'],
     'wp_list_bookmarks' => ['($args is array{echo: false|0}&array ? string : void)'],
     'wp_list_categories' => ['($args is array{echo: false|0}&array ? string|false : false|void)'],


### PR DESCRIPTION
Adding the `phpstan` prefix to the `@template` tag for consistency. We always use the prefixed version. This does not affect functionality, unless a static analyser supports `@template` but not `@phpstan-template`. However, we are not concerned about this, as we use the prefix for all other relevant tags as well.