### PR TITLE
Narrow return type of block_version()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -53,6 +53,7 @@ return [
     'add_theme_page' => [null, 'callback' => "''|callable"],
     'add_users_page' => [null, 'callback' => "''|callable"],
     'addslashes_gpc' => ['T', '@phpstan-template' => 'T', 'gpc' => 'T'],
+    'block_version' => ["(\$content is '' ? 0 : 0|1)"],
     'bool_from_yn' => ["(\$yn is 'y' ? true : false)"],
     'check_admin_referer' => ['1|2|false', 'action' => '-1|string'],
     'check_ajax_referer' => ['1|2|false', 'action' => '-1|string'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -15,6 +15,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/_get_list_table.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/_wp_json_sanity_check.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/absint.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/block_version.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/bool_from_yn.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/current_time.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/echo_parameter.php');
@@ -36,11 +37,11 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_regex.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_sites.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_tags.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_taxonomies.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_taxonomies_for_attachments.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_term_by.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_terms.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_taxonomies.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_term.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_taxonomies_for_attachments.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_user.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_user_by.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/has_filter.php');

--- a/tests/data/block_version.php
+++ b/tests/data/block_version.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function block_version;
+use function PHPStan\Testing\assertType;
+
+// Returns input for non-negative integers
+assertType('0', block_version(''));
+assertType('0|1', block_version('content'));
+assertType('0|1', block_version(Faker::string()));


### PR DESCRIPTION
See [WP Dev Resources for block_version()](https://developer.wordpress.org/reference/functions/block_version/)