### PR TITLE
Narrow return type of wp_cron()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -124,6 +124,7 @@ return [
     'validate_file' => ["(\$file is '' ? 0 : (\$allowed_files is empty ? 0|1|2 : 0|1|2|3))"],
     'wp_clear_scheduled_hook' => ['(int<0, max>|($wp_error is false ? false : \WP_Error))', 'args' => $cronArgsType],
     'wp_create_nonce' => [null, 'action' => '-1|string'],
+    'wp_cron' => ['false|int<0, max>|void'],
     'wp_debug_backtrace_summary' => ['($pretty is true ? string : list<string>)'],
     'wp_die' => ['($args is array{exit: false}&array ? void : never)'],
     'wp_dropdown_languages' => ["(\$args is array{id: null|''}&array ? void : (\$args is array{name: null|''}&array ? void : string))"],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -54,6 +54,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/stripslashes.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/validate_file.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_cron.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_debug_backtrace_summary.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_die.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_dropdown_languages.php');

--- a/tests/data/wp_cron.php
+++ b/tests/data/wp_cron.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Note:
+ * Starting from PHPStan 1.10.49, void types, including void in unions, are
+ * transformed into null.
+ *
+ * @link https://github.com/phpstan/phpstan-src/pull/2778
+ */
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_cron;
+use function PHPStan\Testing\assertType;
+
+assertType('int<0, max>|false|null', wp_cron());


### PR DESCRIPTION
> false|int|void On success an integer indicating number of events spawned (0 indicates no events needed to be spawned), false if spawning fails for one or more events or void if the function registered [_wp_cron()](https://developer.wordpress.org/reference/functions/_wp_cron/) to run on the action.

See [WP Dev Resources for wp_cron()](https://developer.wordpress.org/reference/functions/wp_cron/)