### PR TITLE
Narrow return type of prep_atom_text_construct()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -101,6 +101,7 @@ return [
     'next_posts' => ['($display is true ? void : string)'],
     'paginate_links' => ["(\$args is array{total: int<min, 1>}&array ? void : (\$args is array{type: 'array'}&array ? list<string> : string))"],
     'post_type_archive_title' => ['($display is true ? void : string|void)'],
+    'prep_atom_text_construct' => ["array{'html'|'text'|'xhtml', string}"],
     'previous_posts' => ['($display is true ? void : string)'],
     'rawurlencode_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'rest_ensure_response' => ['($response is WP_Error ? WP_Error : WP_REST_Response)'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -50,6 +50,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/is_wp_error.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql2date.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/paginate_links.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/prep_atom_text_construct.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/rest_ensure_response.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/size_format.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/stripslashes.php');

--- a/tests/data/prep_atom_text_construct.php
+++ b/tests/data/prep_atom_text_construct.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function prep_atom_text_construct;
+use function PHPStan\Testing\assertType;
+
+assertType("array{'html'|'text'|'xhtml', string}", prep_atom_text_construct(''));
+assertType("array{'html'|'text'|'xhtml', string}", prep_atom_text_construct('data'));
+assertType("array{'html'|'text'|'xhtml', string}", prep_atom_text_construct(Faker::string()));


### PR DESCRIPTION
```php
// Return statements ($data is a string)
return array( 'text', $data );
return array( 'html', "<![CDATA[$data]]>" );
return array( 'text', $data );
return array( 'xhtml', $data );
return array( 'html', "<![CDATA[$data]]>" );
return array( 'html', htmlspecialchars( $data ) );
```

See [WP Dev Resources for prep_atom_text_construct()](https://developer.wordpress.org/reference/functions/prep_atom_text_construct/)