### PR TITLE
Narrow return type and parameter type for zeroise()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -180,6 +180,7 @@ return [
     'wp_update_post' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_verify_nonce' => ['1|2|false', 'action' => '-1|string'],
     'wp_widget_rss_form' => ['void', 'args' => $wpWidgetRssFormArgsType, 'inputs' => $wpWidgetRssFormInputsType],
+    'zeroise' => ['($threshold is 0 ? lowercase-string&non-empty-string&numeric-string : ($number is int<0, max> ? lowercase-string&non-empty-string&numeric-string : lowercase-string&non-empty-string))', 'threshold' => 'int<0, max>'],
     // Classes, methods, and properties
     'Custom_Image_Header::set_header_image' => [null, 'choice' => 'string|array{attachment_id: int<1, max>, url: string, width: int<0, max>, height: int<0, max>}'],
     'Custom_Image_Header::show_header_selector' => [null, 'type' => "'default'|'uploaded'"],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -82,6 +82,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_unique_id.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_widget_factory.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wpdb.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/zeroise.php');
     }
 
     /**

--- a/tests/data/zeroise.php
+++ b/tests/data/zeroise.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function zeroise;
+use function PHPStan\Testing\assertType;
+
+// $threshold is 0
+assertType('lowercase-string&non-empty-string&numeric-string', zeroise(-1, 0));
+assertType('lowercase-string&non-empty-string&numeric-string', zeroise(0, 0));
+assertType('lowercase-string&non-empty-string&numeric-string', zeroise(1, 0));
+assertType('lowercase-string&non-empty-string&numeric-string', zeroise(Faker::int(), 0));
+
+// $threshold > 0
+assertType('lowercase-string&non-empty-string', zeroise(-1, 5));
+assertType('lowercase-string&non-empty-string&numeric-string', zeroise(0, 5));
+assertType('lowercase-string&non-empty-string&numeric-string', zeroise(1, 5));
+assertType('lowercase-string&non-empty-string', zeroise(Faker::int(), 5));
+
+// $threshold is unknown
+assertType('lowercase-string&non-empty-string', zeroise(-1, Faker::nonNegativeInt()));
+assertType('lowercase-string&non-empty-string&numeric-string', zeroise(0, Faker::nonNegativeInt()));
+assertType('lowercase-string&non-empty-string&numeric-string', zeroise(1, Faker::nonNegativeInt()));
+assertType('lowercase-string&non-empty-string', zeroise(Faker::int(), Faker::nonNegativeInt()));


### PR DESCRIPTION
> Return
`string` Adds leading zeros to number if needed.

```php
function zeroise( $number, $threshold ) {
	return sprintf( '%0' . $threshold . 's', $number );
}
```

See [WP Dev Resources for zeroise()](https://developer.wordpress.org/reference/functions/zeroise/)

Depending on the value of `$number` and `$threshold`, the return type may also be a `numeric-string` in addition to `lowercase-string&non-empty-string`. Hence the conditional return type.

For the documented behaviour of `zeroise()` (i.e. adding leading zeros), `$threshold` must be a non-negative integer. If `$threshold` is negative, the function instead adds **trailing** zeros. Hence the narrowing of the `$threshold` parameter type.

Depending on the values of `$number` and `$threshold`, the return type may also be a `numeric-string`. Hence the use of a conditional return type.
