### PR TITLE
Narrow return type of trailingslashit()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -122,6 +122,7 @@ return [
     'the_date' => ['($display is true ? void : string)'],
     'the_modified_date' => ['($display is true ? void : string)'],
     'the_title' => ['($display is true ? void : string|void)'],
+    'trailingslashit' => ['non-falsy-string'],
     'urldecode_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'urlencode_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'validate_file' => ["(\$file is '' ? 0 : (\$allowed_files is empty ? 0|1|2 : 0|1|2|3))"],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -55,6 +55,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/size_format.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/stripslashes.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/trailingslashit.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/validate_file.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_cron.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_debug_backtrace_summary.php');

--- a/tests/data/trailingslashit.php
+++ b/tests/data/trailingslashit.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function trailingslashit;
+use function PHPStan\Testing\assertType;
+
+assertType('non-falsy-string', trailingslashit(''));
+assertType('non-falsy-string', trailingslashit('value'));
+assertType('non-falsy-string', trailingslashit(Faker::string()));


### PR DESCRIPTION
> `string` String with trailing slash added.

See [WP Dev Resources for trailingslashit()](https://developer.wordpress.org/reference/functions/trailingslashit/)