### PR TITLE
Narrow return type and parameter type for get_block_wrapper_attributes()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -63,6 +63,7 @@ return [
     'edit_term_link' => ['($display is true ? void : string|void)'],
     'get_approved_comments' => ["(\$args is array{count: true}&array ? int : (\$args is array{fields: 'ids'}&array ? array<int, int> : array<int, \WP_Comment>))"],
     'get_attachment_taxonomies' => ["(\$output is 'names' ? array<int, string> : array<string, \WP_Taxonomy>)"],
+    'get_block_wrapper_attributes' => ['($extra_attributes is empty ? string : non-falsy-string)', 'extra_attributes' => 'array<string, string>'],
     'get_bookmark' => ["null|(\$output is 'ARRAY_A' ? array<string, mixed> : (\$output is 'ARRAY_N' ? array<int, mixed> : \stdClass))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'"],
     'get_calendar' => ['($args is array{display: false}&array ? string : void)'],
     'get_categories' => ["(\$args is array{fields: 'count'}&array ? list<numeric-string> : (\$args is array{fields: 'names'|'slugs'}&array ? list<string> : (\$args is array{fields: 'id=>name'|'id=>slug'}&array ? array<int, string> : (\$args is array{fields: 'id=>parent'}&array ? array<int, int> : (\$args is array{fields: 'ids'|'tt_ids'}&array ? list<int> : array<int, \WP_Term>)))))"],

--- a/tests/Faker.php
+++ b/tests/Faker.php
@@ -86,6 +86,20 @@ class Faker
     }
 
     /**
+     * Fakes `bool|Type`. If `$type` is `null`, fakes `bool`.
+     *
+     * @template TKeyOrValue
+     * @template TValue
+     * @param TKeyOrValue $keyOrValueType
+     * @param TValue $valueType
+     * @return (TKeyOrValue is null ? non-empty-array<mixed> : (TValue is null ? non-empty-array<TKeyOrValue> : non-empty-array<TKeyOrValue, TValue>))
+     */
+    public static function nonEmptyArray($keyOrValueType = null, $valueType = null): array
+    {
+        return [$keyOrValueType => $valueType];
+    }
+
+    /**
      * @template T
      * @param T ...$types
      * @return T

--- a/tests/Faker.php
+++ b/tests/Faker.php
@@ -86,7 +86,8 @@ class Faker
     }
 
     /**
-     * Fakes `bool|Type`. If `$type` is `null`, fakes `bool`.
+     * Fakes `non-empty-array<Type>`, `non-empty-array<KeyType, ValueType>`,
+     * and `non-empty-array<mixed>` if no type is specified.
      *
      * @template TKeyOrValue
      * @template TValue

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -22,6 +22,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/Faker.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_approved_comments.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_attachment_taxonomies.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_block_wrapper_attributes.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_bookmark.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_categories.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_category.php');

--- a/tests/data/Faker.php
+++ b/tests/data/Faker.php
@@ -37,6 +37,12 @@ assertType('array<int, string>', Faker::intArray(Faker::string()));
 assertType('array<string, bool>', Faker::strArray(Faker::bool()));
 assertType('list<mixed>', Faker::list());
 
+// Non-empty arrays
+assertType('non-empty-array<mixed>', Faker::nonEmptyArray());
+assertType('non-empty-array<mixed>', Faker::nonEmptyArray(Faker::mixed()));
+assertType('non-empty-array<int>', Faker::nonEmptyArray(Faker::int()));
+assertType('non-empty-array<string, string>', Faker::nonEmptyArray(Faker::string(), Faker::string()));
+
 // Unions
 assertType('bool', Faker::union(Faker::bool()));
 assertType('bool|int', Faker::union(Faker::bool(), Faker::int()));

--- a/tests/data/get_block_wrapper_attributes.php
+++ b/tests/data/get_block_wrapper_attributes.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function get_block_wrapper_attributes;
+use function PHPStan\Testing\assertType;
+
+assertType('string', get_block_wrapper_attributes());
+assertType('string', get_block_wrapper_attributes([]));
+assertType('non-falsy-string', get_block_wrapper_attributes(['class' => 'my-class']));
+
+assertType('non-falsy-string', get_block_wrapper_attributes(Faker::nonEmptyArray(Faker::string(), Faker::string())));
+assertType('string', get_block_wrapper_attributes(Faker::strArray()));


### PR DESCRIPTION
The function `get_block_wrapper_attributes()` generates a string of HTML attributes from the `key => value` pairs provided in two arrays, one of which is the `$extra_attributes` parameter.

- Attributes in the form `key="value"` are invalid when the key is numeric. Therefore, the type of `$extra_attributes` is narrowed to ensure only attributes with string type names are passed.
- The function only returns an empty string if both attribute arrays are empty. Thus, when `$extra_attributes` is non-empty, the return value is a `non-falsy-string`.

See [WP Dev Resources for get_block_wrapper_attributes()](https://developer.wordpress.org/reference/functions/get_block_wrapper_attributes/)

