### PR TITLE
Further narrow return type of wp_unique_id()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -174,7 +174,7 @@ return [
     'wp_tag_cloud' => ["(\$args is array{format: 'array'}&array ? array<int, string>|void : (\$args is array{echo: false|0}&array ? string|void : void))"],
     'wp_title' => ['($display is true ? void : string)'],
     'wp_trigger_error' => [null, 'error_level' => '\E_USER_ERROR|\E_USER_WARNING|\E_USER_NOTICE|\E_USER_DEPRECATED'],
-    'wp_unique_id' => ['($prefix is empty ? numeric-string : ($prefix is numeric ? numeric-string : string))'],
+    'wp_unique_id' => ['($prefix is empty ? numeric-string : ($prefix is numeric ? numeric-string : string))&non-falsy-string'],
     'wp_unschedule_event' => ['($wp_error is false ? bool : true|\WP_Error)', 'args' => $cronArgsType],
     'wp_unschedule_hook' => ['($wp_error is false ? int<0, max>|false : int<0, max>|\WP_Error)'],
     'wp_unslash' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],

--- a/tests/data/wp_unique_id.php
+++ b/tests/data/wp_unique_id.php
@@ -7,10 +7,10 @@ namespace PhpStubs\WordPress\Core\Tests;
 use function wp_unique_id;
 use function PHPStan\Testing\assertType;
 
-assertType('numeric-string', wp_unique_id());
-assertType('numeric-string', wp_unique_id(''));
-assertType('numeric-string', wp_unique_id('1'));
-assertType('numeric-string', wp_unique_id(Faker::numericString()));
+assertType('non-falsy-string&numeric-string', wp_unique_id());
+assertType('non-falsy-string&numeric-string', wp_unique_id(''));
+assertType('non-falsy-string&numeric-string', wp_unique_id('1'));
+assertType('non-falsy-string&numeric-string', wp_unique_id(Faker::numericString()));
 
-assertType('string', wp_unique_id('string'));
-assertType('string', wp_unique_id(Faker::string()));
+assertType('non-falsy-string', wp_unique_id('string'));
+assertType('non-falsy-string', wp_unique_id(Faker::string()));


### PR DESCRIPTION
```php
function wp_unique_id( $prefix = '' ) {
	static $id_counter = 0;
	return $prefix . (string) ++$id_counter;
}
```
See [WP Dev Resources for wp_unique_id()](https://developer.wordpress.org/reference/functions/wp_unique_id/)

- At least the counter is returned, hence non-empty
- The lowest numeric value returned is `'1'`, hence non-falsy.