### PR TITLE
Narrow return type of wp_unique_prefixed_id()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -184,6 +184,7 @@ return [
     'wp_title' => ['($display is true ? void : string)'],
     'wp_trigger_error' => [null, 'error_level' => '\E_USER_ERROR|\E_USER_WARNING|\E_USER_NOTICE|\E_USER_DEPRECATED'],
     'wp_unique_id' => ['($prefix is empty ? numeric-string : ($prefix is numeric ? numeric-string : string))&non-falsy-string'],
+    'wp_unique_prefixed_id' => ['($prefix is empty ? numeric-string : ($prefix is numeric ? numeric-string : string))&non-falsy-string'],
     'wp_unschedule_event' => ['($wp_error is false ? bool : true|\WP_Error)', 'args' => $cronArgsType],
     'wp_unschedule_hook' => ['($wp_error is false ? int<0, max>|false : int<0, max>|\WP_Error)'],
     'wp_unslash' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],

--- a/tests/data/wp_unique_id.php
+++ b/tests/data/wp_unique_id.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpStubs\WordPress\Core\Tests;
 
 use function wp_unique_id;
+use function wp_unique_prefixed_id;
 use function PHPStan\Testing\assertType;
 
 assertType('non-falsy-string&numeric-string', wp_unique_id());
@@ -14,3 +15,11 @@ assertType('non-falsy-string&numeric-string', wp_unique_id(Faker::numericString(
 
 assertType('non-falsy-string', wp_unique_id('string'));
 assertType('non-falsy-string', wp_unique_id(Faker::string()));
+
+assertType('non-falsy-string&numeric-string', wp_unique_prefixed_id());
+assertType('non-falsy-string&numeric-string', wp_unique_prefixed_id(''));
+assertType('non-falsy-string&numeric-string', wp_unique_prefixed_id('1'));
+assertType('non-falsy-string&numeric-string', wp_unique_prefixed_id(Faker::numericString()));
+
+assertType('non-falsy-string', wp_unique_prefixed_id('string'));
+assertType('non-falsy-string', wp_unique_prefixed_id(Faker::string()));


### PR DESCRIPTION
`wp_unique_prefixed_id()` behaves similar to `wp_unique_id()`.

See [WP Dev Resources for wp_unique_id()](https://developer.wordpress.org/reference/functions/wp_unique_prefixed_id/)

- At least the counter is returned, hence non-empty
- The lowest numeric value returned is `'1'`, hence non-falsy.

Cherry picked #308 