### PR TITLE
Narrow return type of wp_get_speculation_rules_configuration()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -142,6 +142,7 @@ return [
     'wp_get_schedule' => [null, 'args' => $cronArgsType],
     'wp_get_scheduled_event' => [null, 'args' => $cronArgsType],
     'wp_get_server_protocol' => ["'HTTP/1.0'|'HTTP/1.1'|'HTTP/2'|'HTTP/2.0'|'HTTP/3'"],
+    'wp_get_speculation_rules_configuration' => ["array{mode: 'prefetch'|'prerender', eagerness: 'conservative'|'eager'|'moderate'}|null"],
     'wp_insert_attachment' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_insert_category' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_insert_link' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -70,6 +70,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_post_terms.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_object_terms.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_server_protocol.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_speculation_rules_configuration.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_is_numeric_array.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_list_bookmarks.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_list_categories.php');

--- a/tests/data/wp_get_speculation_rules_configuration.php
+++ b/tests/data/wp_get_speculation_rules_configuration.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_get_speculation_rules_configuration;
+use function PHPStan\Testing\assertType;
+
+assertType("array{mode: 'prefetch'|'prerender', eagerness: 'conservative'|'eager'|'moderate'}|null", wp_get_speculation_rules_configuration());


### PR DESCRIPTION
> `array<string, string>|null` Associative array with 'mode' and 'eagerness' keys, or null if speculative loading is disabled.

> There are two aspects to the configuration:
	 * The "mode" (whether to "prefetch" or "prerender" URLs).
	 * The "eagerness" (whether to speculatively load URLs in an "eager", "moderate", or "conservative" way).

See https://github.com/WordPress/wordpress-develop/blob/6.8.2/src/wp-includes/speculative-loading.php#L18