### PR TITLE
Narrow return type of get_current_user_id()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -70,6 +70,7 @@ return [
     'get_category_by_path' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|\WP_Error|null : (\$output is 'ARRAY_N' ? array<int, mixed>|\WP_Error|null : \WP_Term|\WP_Error|null))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'"],
     'get_comment' => ["(\$comment is \WP_Comment ? array<array-key, mixed>|\WP_Comment : array<array-key, mixed>|\WP_Comment|null) & (\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Comment|null))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'"],
     'get_current_blog_id' => ['int<0, max>'],
+    'get_current_user_id' => ['int<0, max>'],
     'get_html_split_regex' => ['non-falsy-string'],
     'get_object_taxonomies' => ["(\$output is 'names' ? array<int, string> : array<string, \WP_Taxonomy>)"],
     'get_page_by_path' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -27,6 +27,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_category.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_category_by_path.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_comment.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_current_id.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_object_taxonomies.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_post.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_post_stati.php');

--- a/tests/data/get_current_id.php
+++ b/tests/data/get_current_id.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function get_current_blog_id;
+use function get_current_user_id;
+use function PHPStan\Testing\assertType;
+
+assertType('int<0, max>', get_current_blog_id());
+
+assertType('int<0, max>', get_current_user_id());


### PR DESCRIPTION
> `int` The current user’s ID, or 0 if no user is logged in.

See [WP Dev Resources](https://developer.wordpress.org/reference/functions/get_current_user_id/)