### PR TITLE
Narrow return type of image_link_input_fields()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -99,6 +99,7 @@ return [
     'has_action' => ['($callback is false ? bool : false|int)'],
     'has_filter' => ['($callback is false ? bool : false|int)'],
     'have_posts' => [null, '@phpstan-impure' => ''],
+    'image_link_input_fields' => ['non-falsy-string'],
     'image_size_input_fields' => ["array{label: string, input: 'html', html: string}"],
     'is_new_day' => ['0|1'],
     'is_term' => ["(\$term is 0 ? 0 : (\$term is '' ? null : (\$taxonomy is '' ? string|null : array{term_id: string, term_taxonomy_id: string}|null)))"],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -49,6 +49,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_user_by.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/has_filter.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/have_posts.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/image_link_input_fields.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/image_size_input_fields.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/is_new_day.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/is_wp_error.php');

--- a/tests/data/image_link_input_fields.php
+++ b/tests/data/image_link_input_fields.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function image_link_input_fields;
+use function PHPStan\Testing\assertType;
+
+assertType('non-falsy-string', image_link_input_fields(Faker::wpPost()));
+assertType('non-falsy-string', image_link_input_fields(Faker::wpPost(), ''));
+assertType('non-falsy-string', image_link_input_fields(Faker::wpPost(), 'url_type'));
+assertType('non-falsy-string', image_link_input_fields(Faker::wpPost(), Faker::string()));


### PR DESCRIPTION
The function `image_link_input_fields()` always returns a string containing HTML markup. Therefore, its return type can be narrowed to `non-falsy-string`.

```php
return "
	<input type='text' class='text urlfield' name='attachments[$post->ID][url]' value='" . esc_attr( $url ) . "' /><br />
	<button type='button' class='button urlnone' data-link-url=''>" . __( 'None' ) . "</button>
	<button type='button' class='button urlfile' data-link-url='" . esc_url( $file ) . "'>" . __( 'File URL' ) . "</button>
	<button type='button' class='button urlpost' data-link-url='" . esc_url( $link ) . "'>" . __( 'Attachment Post URL' ) . '</button>
";
```

See the [WP Dev Resources](https://developer.wordpress.org/reference/functions/image_link_input_fields/)