### PR TITLE
Narrow return type of wp_caption_input_textarea()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -131,6 +131,7 @@ return [
     'urldecode_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'urlencode_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'validate_file' => ["(\$file is '' ? 0 : (\$allowed_files is empty ? 0|1|2 : 0|1|2|3))"],
+    'wp_caption_input_textarea' => ['non-falsy-string'],
     'wp_clear_scheduled_hook' => ['(int<0, max>|($wp_error is false ? false : \WP_Error))', 'args' => $cronArgsType],
     'wp_create_nonce' => [null, 'action' => '-1|string'],
     'wp_cron' => ['false|int<0, max>|void'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -61,6 +61,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/stripslashes.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/validate_file.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_caption_input_textarea.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_cron.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_debug_backtrace_summary.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_die.php');

--- a/tests/data/wp_caption_input_textarea.php
+++ b/tests/data/wp_caption_input_textarea.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_caption_input_textarea;
+use function PHPStan\Testing\assertType;
+
+assertType('non-falsy-string', wp_caption_input_textarea(Faker::wpPost()));


### PR DESCRIPTION
The function `wp_caption_input_textarea()` always returns a string containing HTML markup. Therefore, its return type can be narrowed to `non-falsy-string`.

```php
return '<textarea name="' . $name . '" id="' . $name . '">' . $edit_post->post_excerpt . '</textarea>';
```

See the [WP Dev Resources](https://developer.wordpress.org/reference/functions/wp_caption_input_textarea/)