### PR TITLE
Narrow return type of wp_media_insert_url_form()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -161,6 +161,7 @@ return [
     'wp_list_categories' => ['($args is array{echo: false|0}&array ? string|false : false|void)'],
     'wp_list_pages' => ['($args is array{echo: false}&array ? string : void)'],
     'wp_loginout' => ['($display is true ? void : string)'],
+    'wp_media_insert_url_form' => ['non-falsy-string'],
     'wp_next_scheduled' => [null, 'args' => $cronArgsType],
     'wp_nonce_field' => [null, 'action' => '-1|string'],
     'wp_nonce_url' => [null, 'action' => '-1|string'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -81,6 +81,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_list_bookmarks.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_list_categories.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_list_pages.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_media_insert_url_form.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_parse_list.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_query.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_rest_request.php');

--- a/tests/data/wp_media_insert_url_form.php
+++ b/tests/data/wp_media_insert_url_form.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_media_insert_url_form;
+use function PHPStan\Testing\assertType;
+
+assertType('non-falsy-string', wp_media_insert_url_form());
+assertType('non-falsy-string', wp_media_insert_url_form(''));
+assertType('non-falsy-string', wp_media_insert_url_form('image'));
+assertType('non-falsy-string', wp_media_insert_url_form('not-image'));
+assertType('non-falsy-string', wp_media_insert_url_form(Faker::string()));


### PR DESCRIPTION
The function `wp_media_insert_url_form()` always returns a string containing HTML markup (see [WP Dev Resources](https://developer.wordpress.org/reference/functions/wp_media_insert_url_form/)). Therefore, its return type can be narrowed to `non-falsy-string`.