### PR TITLE
Narrow return type of get_site_screen_help_tab_args() and get_site_screen_help_sidebar_content()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -85,6 +85,8 @@ return [
     'get_query_pagination_arrow' => ['non-falsy-string|null'],
     'get_shortcode_regex' => ['non-falsy-string'],
     'get_shortcode_atts_regex' => ['non-falsy-string'],
+    'get_site_screen_help_tab_args' => ["array{id: 'overview', title: string, content: non-falsy-string}"],
+    'get_site_screen_help_sidebar_content' => ['non-falsy-string'],
     'get_sites' => ["(\$args is array{count: true}&array ? int : (\$args is array{fields: 'ids'}&array ? array<int, int> : array<int, \WP_Site>))"],
     'get_tag_regex' => ['non-falsy-string'],
     'get_tags' => ["(\$args is array{fields: 'count'}&array ? numeric-string : (\$args is array{fields: 'names'|'slugs'}&array ? list<string> : (\$args is array{fields: 'id=>name'|'id=>slug'}&array ? array<int, string> : (\$args is array{fields: 'id=>parent'}&array ? array<int, int> : (\$args is array{fields: 'ids'|'tt_ids'}&array ? list<int> : array<int, \WP_Term>)))))|\WP_Error"],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -38,6 +38,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_pagination_arrow.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_permalink.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_regex.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_site_screen_help.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_sites.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_tags.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_taxonomies.php');

--- a/tests/data/get_site_screen_help.php
+++ b/tests/data/get_site_screen_help.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function get_site_screen_help_sidebar_content;
+use function get_site_screen_help_tab_args;
+use function PHPStan\Testing\assertType;
+
+assertType('non-falsy-string', get_site_screen_help_sidebar_content());
+
+assertType("array{id: 'overview', title: string, content: non-falsy-string}", get_site_screen_help_tab_args());


### PR DESCRIPTION
The function [`get_site_screen_help_sidebar_content()`](https://developer.wordpress.org/reference/functions/get_site_screen_help_sidebar_content/) always returns a string containing HTML markup. Therefore, its return type can be narrowed to `non-falsy-string`.

The function [`get_site_screen_help_tab_args()`](https://developer.wordpress.org/reference/functions/get_site_screen_help_tab_args/) returns a single associative array whose values depend solely on translations. As such, its return type can be narrowed to an array shape.