### PR TITLE
Narrow return type of wp_nav_menu_manage_columns()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -167,6 +167,7 @@ return [
     'wp_list_pages' => ['($args is array{echo: false}&array ? string : void)'],
     'wp_loginout' => ['($display is true ? void : string)'],
     'wp_media_insert_url_form' => ['non-falsy-string'],
+    'wp_nav_menu_manage_columns' => ["array{_title: string, cb: '<input type=\"checkbox\" />', link-target: string, title-attribute: string, css-classes: string, xfn: string, description: string}"],
     'wp_next_scheduled' => [null, 'args' => $cronArgsType],
     'wp_nonce_field' => [null, 'action' => '-1|string'],
     'wp_nonce_url' => [null, 'action' => '-1|string'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -86,6 +86,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_list_categories.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_list_pages.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_media_insert_url_form.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_nav_menu_manage_columns.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_parse_list.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_query.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_rest_request.php');

--- a/tests/data/wp_nav_menu_manage_columns.php
+++ b/tests/data/wp_nav_menu_manage_columns.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_nav_menu_manage_columns;
+use function PHPStan\Testing\assertType;
+
+assertType("array{_title: string, cb: '<input type=\"checkbox\" />', link-target: string, title-attribute: string, css-classes: string, xfn: string, description: string}", wp_nav_menu_manage_columns());


### PR DESCRIPTION
The function [`wp_nav_menu_manage_columns()`](https://developer.wordpress.org/reference/functions/wp_nav_menu_manage_columns/) returns a single associative array whose values depend solely on translations. As such, its return type can be narrowed to an array shape.