### PR TITLE
Narrow return type of validate_plugin()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -135,6 +135,7 @@ return [
     'urldecode_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'urlencode_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'validate_file' => ["(\$file is '' ? 0 : (\$allowed_files is empty ? 0|1|2 : 0|1|2|3))"],
+    'validate_plugin' => ['($plugin is empty ? \WP_Error : 0|\WP_Error)'],
     'wp_caption_input_textarea' => ['non-falsy-string'],
     'wp_clear_scheduled_hook' => ['(int<0, max>|($wp_error is false ? false : \WP_Error))', 'args' => $cronArgsType],
     'wp_create_nonce' => [null, 'action' => '-1|string'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -64,6 +64,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/stripslashes.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/validate_file.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/validate_plugin.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_caption_input_textarea.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_cron.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_debug_backtrace_summary.php');

--- a/tests/data/validate_plugin.php
+++ b/tests/data/validate_plugin.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function validate_plugin;
+use function PHPStan\Testing\assertType;
+
+assertType('WP_Error', validate_plugin(''));
+assertType('0|WP_Error', validate_plugin('pluginPath'));
+assertType('0|WP_Error', validate_plugin(Faker::string()));


### PR DESCRIPTION
> `int|WP_Error` 0 on success, WP_Error on failure.

See [WP Dev Resources](https://developer.wordpress.org/reference/functions/validate_plugin/)

Accordingly, the return type has been narrowed to `int|WP_Error`. `validate_plugin()` always returns `WP_Error` if `$plugin` is an empty string; therefore, a conditional return has been added.