### PR TITLE
Narrow return type of get_available_post_statuses()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -63,6 +63,7 @@ return [
     'edit_term_link' => ['($display is true ? void : string|void)'],
     'get_approved_comments' => ["(\$args is array{count: true}&array ? int : (\$args is array{fields: 'ids'}&array ? array<int, int> : array<int, \WP_Comment>))"],
     'get_attachment_taxonomies' => ["(\$output is 'names' ? array<int, string> : array<string, \WP_Taxonomy>)"],
+    'get_available_post_statuses' => ['list<string>'],
     'get_block_wrapper_attributes' => ['($extra_attributes is empty ? string : non-falsy-string)', 'extra_attributes' => 'array<string, string>'],
     'get_bookmark' => ["null|(\$output is 'ARRAY_A' ? array<string, mixed> : (\$output is 'ARRAY_N' ? array<int, mixed> : \stdClass))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'"],
     'get_calendar' => ['($args is array{display: false}&array ? string : void)'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -22,6 +22,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/Faker.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_approved_comments.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_attachment_taxonomies.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_available_post_statuses.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_block_wrapper_attributes.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_bookmark.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_categories.php');

--- a/tests/data/get_available_post_statuses.php
+++ b/tests/data/get_available_post_statuses.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function get_available_post_statuses;
+use function PHPStan\Testing\assertType;
+
+assertType('list<string>', get_available_post_statuses());

--- a/tests/data/get_available_post_statuses.php
+++ b/tests/data/get_available_post_statuses.php
@@ -8,3 +8,7 @@ use function get_available_post_statuses;
 use function PHPStan\Testing\assertType;
 
 assertType('list<string>', get_available_post_statuses());
+assertType('list<string>', get_available_post_statuses(''));
+assertType('list<string>', get_available_post_statuses('post'));
+assertType('list<string>', get_available_post_statuses('postType'));
+assertType('list<string>', get_available_post_statuses(Faker::string()));


### PR DESCRIPTION
The function [`get_available_post_statuses()`](https://developer.wordpress.org/reference/functions/get_available_post_statuses/) returns the result of `array_keys()`, which is a numerically indexed array. Therefore, its return type can be narrowed to a `list<string>`.
