### PR TITLE
Narrow return type of wp_count_terms()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -140,6 +140,7 @@ return [
     'validate_plugin' => ['($plugin is empty ? \WP_Error : 0|\WP_Error)'],
     'wp_caption_input_textarea' => ['non-falsy-string'],
     'wp_clear_scheduled_hook' => ['(int<0, max>|($wp_error is false ? false : \WP_Error))', 'args' => $cronArgsType],
+    'wp_count_terms' => ['numeric-string|\WP_Error'],
     'wp_create_nonce' => [null, 'action' => '-1|string'],
     'wp_cron' => ['false|int<0, max>|void'],
     'wp_debug_backtrace_summary' => ['($pretty is true ? string : list<string>)'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -68,6 +68,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/validate_file.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/validate_plugin.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_caption_input_textarea.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_count_terms.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_cron.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_debug_backtrace_summary.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_die.php');

--- a/tests/data/wp_count_terms.php
+++ b/tests/data/wp_count_terms.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Note:
+ * Starting from PHPStan 1.10.49, void types, including void in unions, are
+ * transformed into null.
+ *
+ * @link https://github.com/phpstan/phpstan-src/pull/2778
+ */
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_count_terms;
+use function PHPStan\Testing\assertType;
+
+assertType('numeric-string|WP_Error', wp_count_terms());
+assertType('numeric-string|WP_Error', wp_count_terms([]));
+assertType('numeric-string|WP_Error', wp_count_terms(['key' => 'value']));
+assertType('numeric-string|WP_Error', wp_count_terms(Faker::strArray()));


### PR DESCRIPTION
The function [`wp_count_terms()`](https://developer.wordpress.org/reference/functions/wp_count_terms/) returns
> `string|WP_Error` Numeric string containing the number of terms in that taxonomy or WP_Error if the taxonomy does not exist.