### PR TITLE
Add cond. return type, type specifier, parameter narrowing for wp_is_…

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -168,6 +168,7 @@ return [
     'wp_insert_post' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_is_numeric_array' => ['(T is array ? (key-of<T> is int ? true : false) : false)', '@phpstan-template' => 'T of mixed', 'data' => 'T', '@phpstan-assert-if-true' => '(T is list ? T : array<int, value-of<T>>) $data'],
     'wp_is_post_revision' => ['($post is \WP_Post ? false|int<0, max> : ($post is int<min, 0> ? false : false|int<0, max>))'],
+    'wp_is_uuid' => ['($version is 4|null ? bool : false)', 'uuid' => 'TUuid', 'version' => '4', '@phpstan-template TUuid' => 'of string', '@phpstan-assert-if-true' => '=TUuid&lowercase-string&non-falsy-string $uuid'],
     'wp_json_encode' => ['non-empty-string|false', 'depth' => 'int<1, max>'],
     'wp_list_bookmarks' => ['($args is array{echo: false|0}&array ? string : void)'],
     'wp_list_categories' => ['($args is array{echo: false|0}&array ? string|false : false|void)'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -89,6 +89,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_speculation_rules_configuration.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_is_numeric_array.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_is_post_revision.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_is_uuid.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_list_bookmarks.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_list_categories.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_list_pages.php');

--- a/tests/data/wp_is_uuid.php
+++ b/tests/data/wp_is_uuid.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_is_uuid;
+use function PHPStan\Testing\assertType;
+
+/*
+ * Check return type
+ */
+
+// Default $version
+assertType('bool', wp_is_uuid(''));
+assertType('bool', wp_is_uuid('abc'));
+assertType('bool', wp_is_uuid(Faker::string()));
+
+// $version = 4
+assertType('bool', wp_is_uuid('', 4));
+assertType('bool', wp_is_uuid('foo', 4));
+assertType('bool', wp_is_uuid(Faker::string(), 4));
+
+// $version != 4
+assertType('false', wp_is_uuid('', 1));
+assertType('false', wp_is_uuid('foo', 1));
+assertType('false', wp_is_uuid(Faker::string(), 1));
+
+// Unknown version
+assertType('bool', wp_is_uuid('', Faker::int()));
+assertType('bool', wp_is_uuid('foo', Faker::int()));
+assertType('bool', wp_is_uuid(Faker::string(), Faker::int()));
+
+/*
+ * Check type specification
+ */
+
+$uuid = Faker::string();
+
+if (wp_is_uuid($uuid)) {
+    assertType('lowercase-string&non-falsy-string', $uuid);
+}
+assertType('string', $uuid);
+
+if (! wp_is_uuid($uuid)) {
+    assertType('string', $uuid);
+    return;
+}
+assertType('lowercase-string&non-falsy-string', $uuid);
+
+$uuid = 'foo';
+
+if (wp_is_uuid($uuid)) {
+    assertType("'foo'", $uuid);
+}
+assertType("'foo'", $uuid);
+
+if (! wp_is_uuid($uuid)) {
+    assertType("'foo'", $uuid);
+    return;
+}
+assertType("'foo'", $uuid);


### PR DESCRIPTION
- If `$version` is provided, `$version !== 4` triggers `_doing_it_wrong()`.
- If `$version` is provided, `wp_is_uuid()` will always return `false` if `$version !== 4`.
- If `wp_is_uuid($value) === true`, `$value` is a lowercase, non-falsy string.

See [WP Developer Resources](https://developer.wordpress.org/reference/functions/wp_is_uuid/).

Note: The `=` in front of the type in `@phpstan-assert-if-true =TUuid&lowercase-string&non-falsy-string $uuid` is necessary because [PHPStan automatically makes assumptions about `false`](https://phpstan.org/writing-php-code/narrowing-types#equality-assertions) unless the `=` is included. For constant strings, omitting the `=` would result in `*NEVER*` types.
