### PR TITLE
Narrow return type of wp_generate_uuid4()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -149,6 +149,7 @@ return [
     'wp_dropdown_languages' => ["(\$args is array{id: null|''}&array ? void : (\$args is array{name: null|''}&array ? void : string))"],
     'wp_extract_urls' => ['($content is empty ? array{} : list<string>)'],
     'wp_generate_tag_cloud' => ["(\$args is array{format: 'array'}&array ? array<int, string> : string)"],
+    'wp_generate_uuid4' => ['lowercase-string&non-falsy-string'],
     'wp_get_archives' => ['($args is array{echo: false|0}&array ? string|void : void)'],
     'wp_get_comment_status' => ["'approved'|'spam'|'trash'|'unapproved'|false"],
     'wp_get_inline_script_tag' => ['non-falsy-string', 'attributes' => 'array<string, string|true>'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -77,6 +77,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_error_parameter.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_extract_urls.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_generate_tag_cloud.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_generate_uuid4.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_archives.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_comment_status.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_post_categories.php');

--- a/tests/data/wp_generate_uuid4.php
+++ b/tests/data/wp_generate_uuid4.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_generate_uuid4;
+use function PHPStan\Testing\assertType;
+
+assertType('lowercase-string&non-falsy-string', wp_generate_uuid4());


### PR DESCRIPTION
```php
function wp_generate_uuid4() {
	return sprintf(
		'%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
		mt_rand( 0, 0xffff ),
		mt_rand( 0, 0xffff ),
		mt_rand( 0, 0xffff ),
		mt_rand( 0, 0x0fff ) | 0x4000,
		mt_rand( 0, 0x3fff ) | 0x8000,
		mt_rand( 0, 0xffff ),
		mt_rand( 0, 0xffff ),
		mt_rand( 0, 0xffff )
	);
}
```

See [WP Dev Resources](https://developer.wordpress.org/reference/functions/wp_generate_uuid4/)