### PR TITLE
Narrow return type of wp_is_post_revision()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -166,6 +166,7 @@ return [
     'wp_insert_link' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_insert_post' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_is_numeric_array' => ['(T is array ? (key-of<T> is int ? true : false) : false)', '@phpstan-template' => 'T of mixed', 'data' => 'T', '@phpstan-assert-if-true' => '(T is list ? T : array<int, value-of<T>>) $data'],
+    'wp_is_post_revision' => ['($post is \WP_Post ? false|int<0, max> : ($post is int<min, 0> ? false : false|int<0, max>))'],
     'wp_json_encode' => ['non-empty-string|false', 'depth' => 'int<1, max>'],
     'wp_list_bookmarks' => ['($args is array{echo: false|0}&array ? string : void)'],
     'wp_list_categories' => ['($args is array{echo: false|0}&array ? string|false : false|void)'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -87,6 +87,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_server_protocol.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_speculation_rules_configuration.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_is_numeric_array.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_is_post_revision.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_list_bookmarks.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_list_categories.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_list_pages.php');

--- a/tests/data/wp_is_post_revision.php
+++ b/tests/data/wp_is_post_revision.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_is_post_revision;
+use function PHPStan\Testing\assertType;
+
+assertType('false', wp_is_post_revision(0));
+assertType('false', wp_is_post_revision(Faker::nonPositiveInt()));
+assertType('int<0, max>|false', wp_is_post_revision(123));
+assertType('int<0, max>|false', wp_is_post_revision(Faker::int()));
+assertType('int<0, max>|false', wp_is_post_revision(Faker::positiveInt()));
+assertType('int<0, max>|false', wp_is_post_revision(Faker::wpPost()));


### PR DESCRIPTION
The function [`wp_is_post_revision()`](https://developer.wordpress.org/reference/functions/wp_is_post_revision/) returns  
> int|false ID of revision’s parent on success, false if not a revision.

- If it's possible for revisions to be orphaned, the parent ID may be `0`; therefore, the return type is narrowed to `int<0, max>` rather than `int<1, max>`.
- For invalid IDs (`<0`), `wp_is_post_revision()` always returns `false`. Accordingly, a conditional return type has been added.
