### PR TITLE
Narrow return type of wp_http_validate_url()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -164,6 +164,7 @@ return [
     'wp_get_server_protocol' => ["'HTTP/1.0'|'HTTP/1.1'|'HTTP/2'|'HTTP/2.0'|'HTTP/3'"],
     'wp_get_speculation_rules_configuration' => ["array{mode: 'prefetch'|'prerender', eagerness: 'conservative'|'eager'|'moderate'}|null"],
     'wp_hash' => ['lowercase-string&non-falsy-string', 'scheme' => "'auth'|'logged_in'|'nonce'|'secure_auth'"],
+    'wp_http_validate_url' => ["(TUrl is numeric|'' ? false : TUrl|false)", '@phpstan-template TUrl' => 'of string', 'url' => 'TUrl'],
     'wp_insert_attachment' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_insert_category' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_insert_link' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],

--- a/tests/Faker.php
+++ b/tests/Faker.php
@@ -19,7 +19,9 @@ namespace PhpStubs\WordPress\Core\Tests;
  * @method static float float()
  * @method static string string()
  * @method static non-empty-string nonEmptyString()
+ * @method static lowercase-string lowercaseString()
  * @method static numeric-string numericString()
+ * @method static non-falsy-string nonFalsyString()
  * @method static resource resource()
  * @method static object object()
  * @method static mixed mixed()
@@ -111,5 +113,19 @@ class Faker
     public static function union(...$types)
     {
         return $types[0];
+    }
+
+    /**
+     * @template TType1
+     * @template TType2
+     * @param TType1 $type1
+     * @param TType2 $type2
+     * @return (TType1&TType2)
+     *
+     * @phpcs:disable NeutronStandard.Functions.TypeHint
+     * @phpstan-ignore return.missing
+     */
+    public static function intersection($type1, $type2)
+    {
     }
 }

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -88,6 +88,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_server_protocol.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_speculation_rules_configuration.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_hash.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_http_validate_url.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_is_numeric_array.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_is_post_revision.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_is_uuid.php');

--- a/tests/data/Faker.php
+++ b/tests/data/Faker.php
@@ -24,6 +24,7 @@ assertType('float', Faker::float());
 assertType('string', Faker::string());
 assertType('numeric-string', Faker::numericString());
 assertType('non-empty-string', Faker::nonEmptyString());
+assertType('lowercase-string', Faker::lowercaseString());
 
 // Arrays with default values
 assertType('array<mixed>', Faker::array());
@@ -57,6 +58,11 @@ assertType("'bar'|'foo'", Faker::union('foo', 'bar'));
 assertType('string', Faker::union('foo', Faker::string()));
 assertType("'foo'|int", Faker::union('foo', Faker::int()));
 assertType("array{'baz'}|array{foo: 'bar'}", Faker::union(['foo' => 'bar'], ['baz']));
+
+// Intersections
+assertType('lowercase-string', Faker::intersection(Faker::string(), Faker::lowercaseString()));
+assertType("'foo'", Faker::intersection(Faker::string(), 'foo'));
+assertType('lowercase-string&non-falsy-string', Faker::intersection(Faker::lowercaseString(), Faker::nonFalsyString()));
 
 // Other
 assertType('callable(): mixed', Faker::callable());

--- a/tests/data/wp_http_validate_url.php
+++ b/tests/data/wp_http_validate_url.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_http_validate_url;
+use function PHPStan\Testing\assertType;
+
+assertType('false', wp_http_validate_url(''));
+assertType('false', wp_http_validate_url('1'));
+assertType('false', wp_http_validate_url(Faker::numericString()));
+
+assertType("'url'|false", wp_http_validate_url('url'));
+
+assertType('non-empty-string|false', wp_http_validate_url(Faker::string()));
+assertType('non-empty-string|false', wp_http_validate_url(Faker::nonEmptyString()));
+assertType('non-falsy-string|false', wp_http_validate_url(Faker::nonFalsyString()));
+assertType('(lowercase-string&non-empty-string)|false', wp_http_validate_url(Faker::lowercaseString()));
+assertType('(lowercase-string&non-falsy-string)|false', wp_http_validate_url(Faker::intersection(Faker::lowercaseString(), Faker::nonFalsyString())));


### PR DESCRIPTION
The function [`wp_http_validate_url()`](https://developer.wordpress.org/reference/functions/wp_http_validate_url/) either returns `false` or the validated `$url`.

- A conditional return type has been added to account for cases where `'' === $url || is_numeric( $url )`, which are considered invalid.
- The use of `@template-phpstan` ensures that `$url` is not generalised to `string`.