### PR TITLE
Mark wp_rand as impure

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -183,6 +183,7 @@ return [
     'wp_nonce_url' => [null, 'action' => '-1|string'],
     'wp_parse_list' => ['($input_list is array ? array<scalar> : list<string>)'],
     'wp_parse_str' => [null, '@phpstan-param-out' => 'array<int|string, array|string> $result'],
+    'wp_rand' => [null, '@phpstan-impure' => ''],
     'wp_register' => ['($display is true ? void : string)'],
     'wp_remote_get' => [$httpReturnType],
     'wp_remote_head' => [$httpReturnType],

--- a/tests/data/wp_rand.php
+++ b/tests/data/wp_rand.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_rand;
+use function PHPStan\Testing\assertType;
+
+/*
+ * Check impurity
+ */
+
+if (wp_rand(0, 1) === 1) {
+    assertType('int', wp_rand(0, 1));
+}


### PR DESCRIPTION
By default, PHPStan considers all functions that return a value to be pure (see [docs on impure functions](https://phpstan.org/writing-php-code/phpdocs-basics#impure-functions)). Therefore, functions that are impure, e.g. [`wp_rand()`](https://developer.wordpress.org/reference/functions/wp_rand/), should be explicitly marked as such.

~~I am not sure how to test this.~~