### PR TITLE
Mark get_password_reset_key as impure

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -77,6 +77,7 @@ return [
     'get_html_split_regex' => ['non-falsy-string'],
     'get_object_taxonomies' => ["(\$output is 'names' ? array<int, string> : array<string, \WP_Taxonomy>)"],
     'get_page_by_path' => ["(\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))"],
+    'get_password_reset_key' => [null, '@phpstan-impure' => ''],
     'get_permalink' => ['($post is \WP_Post ? string : string|false)'],
     'get_post' => ["(\$post is \WP_Post ? array<array-key, mixed>|\WP_Post : array<array-key, mixed>|\WP_Post|null) & (\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'" ],
     'get_post_permalink' => ['($post is \WP_Post ? string : string|false)'],

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,4 +15,4 @@ parameters:
         -
             path: tests/Faker.php
             identifier: class.notFound
-            count: 10
+            count: 11

--- a/tests/Faker.php
+++ b/tests/Faker.php
@@ -28,14 +28,15 @@ namespace PhpStubs\WordPress\Core\Tests;
  * @method static callable callable()
  * @method static \stdClass stdClass()
  * @method static \WP_Block wpBlock()
- * @method static \WP_Post wpPost()
- * @method static \WP_Term wpTerm()
  * @method static \WP_Comment wpComment()
+ * @method static \WP_Post wpPost()
+ * @method static \WP_Query wpQuery()
  * @method static \WP_REST_Request wpRestRequest()
+ * @method static \WP_Term wpTerm()
  * @method static \WP_Theme wpTheme()
  * @method static \WP_Translations wpTranslations()
- * @method static \WP_Query wpQuery()
  * @method static \WP_Widget_Factory wpWidgetFactory()
+ * @method static \WP_User wpUser()
  * @method static \wpdb wpdb()
  */
 class Faker

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -40,6 +40,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_permalink.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_plugin_page_hookname.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_regex.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_password_reset_key.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_site_screen_help.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_sites.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_tags.php');

--- a/tests/data/Faker.php
+++ b/tests/data/Faker.php
@@ -78,5 +78,6 @@ assertType('WP_Theme', Faker::wpTheme());
 assertType('WP_Translations', Faker::wpTranslations());
 assertType('WP_Query', Faker::wpQuery());
 assertType('WP_Widget_Factory', Faker::wpWidgetFactory());
+assertType('WP_User', Faker::wpUser());
 assertType('wpdb', Faker::wpdb());
 assertType('mixed', Faker::mixed());

--- a/tests/data/Faker.php
+++ b/tests/data/Faker.php
@@ -66,18 +66,20 @@ assertType('lowercase-string&non-falsy-string', Faker::intersection(Faker::lower
 
 // Other
 assertType('callable(): mixed', Faker::callable());
-assertType('resource', Faker::resource());
+assertType('mixed', Faker::mixed());
 assertType('object', Faker::object());
+assertType('resource', Faker::resource());
 assertType('stdClass', Faker::stdClass());
+
+// WordPress
 assertType('WP_Block', Faker::wpBlock());
-assertType('WP_Post', Faker::wpPost());
-assertType('WP_Term', Faker::wpTerm());
 assertType('WP_Comment', Faker::wpComment());
+assertType('WP_Post', Faker::wpPost());
+assertType('WP_Query', Faker::wpQuery());
 assertType('WP_REST_Request', Faker::wpRestRequest());
+assertType('WP_Term', Faker::wpTerm());
 assertType('WP_Theme', Faker::wpTheme());
 assertType('WP_Translations', Faker::wpTranslations());
-assertType('WP_Query', Faker::wpQuery());
-assertType('WP_Widget_Factory', Faker::wpWidgetFactory());
 assertType('WP_User', Faker::wpUser());
+assertType('WP_Widget_Factory', Faker::wpWidgetFactory());
 assertType('wpdb', Faker::wpdb());
-assertType('mixed', Faker::mixed());

--- a/tests/data/get_password_reset_key.php
+++ b/tests/data/get_password_reset_key.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function get_password_reset_key;
+use function PHPStan\Testing\assertType;
+
+/*
+ * Check impurity
+ */
+
+if (is_wp_error(get_password_reset_key(Faker::wpUser()))) {
+    assertType('string|WP_Error', get_password_reset_key(Faker::wpUser()));
+}
+
+if (! is_wp_error(get_password_reset_key(Faker::wpUser()))) {
+    assertType('string|WP_Error', get_password_reset_key(Faker::wpUser()));
+}
+
+if (is_string(get_password_reset_key(Faker::wpUser()))) {
+    assertType('string|WP_Error', get_password_reset_key(Faker::wpUser()));
+}
+
+if (! is_string(get_password_reset_key(Faker::wpUser()))) {
+    assertType('string|WP_Error', get_password_reset_key(Faker::wpUser()));
+}

--- a/tests/data/get_password_reset_key.php
+++ b/tests/data/get_password_reset_key.php
@@ -11,18 +11,20 @@ use function PHPStan\Testing\assertType;
  * Check impurity
  */
 
-if (is_wp_error(get_password_reset_key(Faker::wpUser()))) {
-    assertType('string|WP_Error', get_password_reset_key(Faker::wpUser()));
+$user = Faker::wpUser();
+
+if (is_wp_error(get_password_reset_key($user))) {
+    assertType('string|WP_Error', get_password_reset_key($user));
 }
 
-if (! is_wp_error(get_password_reset_key(Faker::wpUser()))) {
-    assertType('string|WP_Error', get_password_reset_key(Faker::wpUser()));
+if (! is_wp_error(get_password_reset_key($user))) {
+    assertType('string|WP_Error', get_password_reset_key($user));
 }
 
-if (is_string(get_password_reset_key(Faker::wpUser()))) {
-    assertType('string|WP_Error', get_password_reset_key(Faker::wpUser()));
+if (is_string(get_password_reset_key($user))) {
+    assertType('string|WP_Error', get_password_reset_key($user));
 }
 
-if (! is_string(get_password_reset_key(Faker::wpUser()))) {
-    assertType('string|WP_Error', get_password_reset_key(Faker::wpUser()));
+if (! is_string(get_password_reset_key($user))) {
+    assertType('string|WP_Error', get_password_reset_key($user));
 }


### PR DESCRIPTION
By default, PHPStan considers all functions that return a value to be pure (see [docs on impure functions](https://phpstan.org/writing-php-code/phpdocs-basics#impure-functions)). Therefore, functions that are impure, e.g. [`get_password_reset_key()`](https://developer.wordpress.org/reference/functions/get_password_reset_key/), should be explicitly marked as such.

~~I am not sure how to test this.~~