### PR TITLE
Narrow return type and parameter type of sanitize_title_with_dashes()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -120,6 +120,7 @@ return [
     'sanitize_category' => ['T', '@phpstan-template' => 'T of array|object', 'category' => 'T'],
     'sanitize_post' => ['T', '@phpstan-template' => 'T of array|object', 'post' => 'T'],
     'sanitize_term' => ['T', '@phpstan-template' => 'T of array|object', 'term' => 'T'],
+    'sanitize_title_with_dashes' => ['lowercase-string', 'context' => "'display'|'save'"],
     'single_cat_title' => ['($display is true ? void : string|void)'],
     'single_month_title' => ['($display is true ? false|void : false|string)'],
     'single_post_title' => ['($display is true ? void : string|void)'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -61,6 +61,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/prep_atom_text_construct.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/rest_authorization_required_code.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/rest_ensure_response.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/sanitize_title_with_dashes.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/size_format.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/stripslashes.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');

--- a/tests/data/sanitize_title_with_dashes.php
+++ b/tests/data/sanitize_title_with_dashes.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function sanitize_title_with_dashes;
+use function PHPStan\Testing\assertType;
+
+assertType('lowercase-string', sanitize_title_with_dashes(''));
+assertType('lowercase-string', sanitize_title_with_dashes('title'));
+assertType('lowercase-string', sanitize_title_with_dashes(Faker::string()));
+
+assertType('lowercase-string', sanitize_title_with_dashes('', '', 'display'));
+assertType('lowercase-string', sanitize_title_with_dashes('title', '', 'display'));
+assertType('lowercase-string', sanitize_title_with_dashes(Faker::string(), '', 'display'));
+
+assertType('lowercase-string', sanitize_title_with_dashes('', '', 'save'));
+assertType('lowercase-string', sanitize_title_with_dashes('title', '', 'save'));
+assertType('lowercase-string', sanitize_title_with_dashes(Faker::string(), '', 'save'));
+
+assertType('lowercase-string', sanitize_title_with_dashes('', '', Faker::string()));
+assertType('lowercase-string', sanitize_title_with_dashes('title', '', Faker::string()));
+assertType('lowercase-string', sanitize_title_with_dashes(Faker::string(), '', Faker::string()));
+
+assertType('lowercase-string', sanitize_title_with_dashes('', Faker::string(), Faker::string()));
+assertType('lowercase-string', sanitize_title_with_dashes('title', Faker::string(), Faker::string()));
+assertType('lowercase-string', sanitize_title_with_dashes(Faker::string(), Faker::string(), Faker::string()));


### PR DESCRIPTION
The function [`sanitize_title_with_dashes()`](https://developer.wordpress.org/reference/functions/sanitize_title_with_dashes/) always returns a `lowercase-string` (which may be empty) because of:

```php
if ( seems_utf8( $title ) ) {
	if ( function_exists( 'mb_strtolower' ) ) {
		$title = mb_strtolower( $title, 'UTF-8' );
	}
	$title = utf8_uri_encode( $title, 200 );
}

$title = strtolower( $title );
```

The parameter `$context` is documented as:  
> The operation for which the string is sanitized.
> When set to `save`, additional entities are converted to hyphens or stripped entirely. Default `display`.

This aligns with the function’s behaviour: additional entities are converted when `$context === 'save'`, and not converted otherwise (though not only when `$context === 'display'` but for all `$context !== 'save'` ).

Accordingly, the return type has been narrowed to `lowercase-string`, and the type of `$context` has been narrowed to `'display'|'save'`.
