### PR TITLE
Narrow return type of sanitize_sql_orderby()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -119,6 +119,7 @@ return [
     'rest_ensure_response' => ['($response is WP_Error ? WP_Error : WP_REST_Response)'],
     'sanitize_category' => ['T', '@phpstan-template' => 'T of array|object', 'category' => 'T'],
     'sanitize_post' => ['T', '@phpstan-template' => 'T of array|object', 'post' => 'T'],
+    'sanitize_sql_orderby' => ["(T is non-falsy-string ? T|false : false)", '@phpstan-template T' => 'of string', 'orderby' => 'T'],
     'sanitize_term' => ['T', '@phpstan-template' => 'T of array|object', 'term' => 'T'],
     'single_cat_title' => ['($display is true ? void : string|void)'],
     'single_month_title' => ['($display is true ? false|void : false|string)'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -61,6 +61,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/prep_atom_text_construct.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/rest_authorization_required_code.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/rest_ensure_response.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/sanitize_sql_orderby.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/size_format.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/stripslashes.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');

--- a/tests/data/sanitize_sql_orderby.php
+++ b/tests/data/sanitize_sql_orderby.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function sanitize_sql_orderby;
+use function PHPStan\Testing\assertType;
+
+assertType('false', sanitize_sql_orderby(''));
+assertType("'orderby'|false", sanitize_sql_orderby('orderby'));
+assertType('non-falsy-string|false', sanitize_sql_orderby(Faker::string()));
+assertType('(lowercase-string&non-falsy-string)|false', sanitize_sql_orderby(Faker::lowercaseString()));
+assertType('non-falsy-string|false', sanitize_sql_orderby(Faker::nonEmptyString()));
+assertType('non-falsy-string|false', sanitize_sql_orderby(Faker::nonFalsyString()));
+
+assertType("'Orderby'|(lowercase-string&non-falsy-string)|false", sanitize_sql_orderby(Faker::union('Orderby', Faker::lowercaseString())));
+
+assertType('(lowercase-string&non-falsy-string)|false', sanitize_sql_orderby(Faker::intersection(Faker::lowercaseString(), Faker::nonFalsyString())));


### PR DESCRIPTION
The function [`sanitize_sql_orderby()`](https://developer.wordpress.org/reference/functions/sanitize_sql_orderby/) validates that the string `$orderby` is a valid `ORDER BY` clause. If it is valid, it is returned unchanged; otherwise, `false` is returned.

- A conditional return type has been added to handle cases where the string is always invalid (falsy strings).
- A template has been added to ensure that the returned string is not generalised.
