### PR TITLE
Add conditional return type for rest_sanitize_boolean()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -117,6 +117,7 @@ return [
     'previous_posts' => ['($display is true ? void : string)'],
     'rawurlencode_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'rest_authorization_required_code' => ['401|403'],
+    'rest_sanitize_boolean' => ["(T is bool ? T : (T is int ? (T is 0 ? false : true) : (T is string ? (T is ''|'false'|'FALSE'|'0' ? false : (T[0] is 'f'|'F' ? bool : true)) : true)))", '@phpstan-template T' => 'of bool|string|int', 'value' => 'T'],
     'rest_ensure_response' => ['($response is \WP_Error ? \WP_Error : \WP_REST_Response)'],
     'sanitize_category' => ['T', '@phpstan-template' => 'T of array|object', 'category' => 'T'],
     'sanitize_post' => ['T', '@phpstan-template' => 'T of array|object', 'post' => 'T'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -62,6 +62,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/prep_atom_text_construct.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/rest_authorization_required_code.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/rest_ensure_response.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/rest_sanitize_boolean.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/sanitize_title_with_dashes.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/size_format.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/stripslashes.php');

--- a/tests/data/rest_sanitize_boolean.php
+++ b/tests/data/rest_sanitize_boolean.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function rest_sanitize_boolean;
+use function PHPStan\Testing\assertType;
+
+assertType('true', rest_sanitize_boolean(true));
+assertType('false', rest_sanitize_boolean(false));
+assertType('bool', rest_sanitize_boolean(Faker::bool()));
+
+assertType('false', rest_sanitize_boolean(''));
+assertType('false', rest_sanitize_boolean('0'));
+assertType('false', rest_sanitize_boolean('false'));
+assertType('false', rest_sanitize_boolean('FALSE'));
+assertType('bool', rest_sanitize_boolean('fALSE'));
+assertType('bool', rest_sanitize_boolean('foo'));
+assertType('true', rest_sanitize_boolean('value'));
+assertType('bool', rest_sanitize_boolean(Faker::string()));
+assertType('bool', rest_sanitize_boolean(Faker::nonEmptyString()));
+assertType('bool', rest_sanitize_boolean(Faker::nonFalsyString()));
+
+assertType('false', rest_sanitize_boolean(0));
+assertType('true', rest_sanitize_boolean(123));
+assertType('bool', rest_sanitize_boolean(Faker::int()));
+assertType('true', rest_sanitize_boolean(Faker::positiveInt()));
+assertType('bool', rest_sanitize_boolean(Faker::nonNegativeInt()));


### PR DESCRIPTION
The function [`rest_sanitize_boolean()`](https://developer.wordpress.org/reference/functions/rest_sanitize_boolean/) converts the passed `$value` to a boolean. For strings equal to `'0'` or where `strtolower($value) === 'false'`, the result is `false`; everything else is cast to `bool`.

A conditional return type has been added to reflect this logic. I am not certain which case variations of `'false'` can occur (e.g. `fALSE`, `False`), so every constant string starting with `f` or `F` — except for `false` and `FALSE` — will be treated as `bool`.
