### PR TITLE
Simplify conditional return type of wp_is_numeric_array()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -173,7 +173,7 @@ return [
     'wp_insert_category' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_insert_link' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_insert_post' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
-    'wp_is_numeric_array' => ['(T is array ? (key-of<T> is int ? true : false) : false)', '@phpstan-template' => 'T of mixed', 'data' => 'T', '@phpstan-assert-if-true' => '(T is list ? T : array<int, value-of<T>>) $data'],
+    'wp_is_numeric_array' => ['(T is array<int, mixed> ? true : false)', '@phpstan-template' => 'T of mixed', 'data' => 'T', '@phpstan-assert-if-true' => '(T is list ? T : array<int, mixed>) $data'],
     'wp_is_post_revision' => ['($post is \WP_Post ? false|int<0, max> : ($post is int<min, 0> ? false : false|int<0, max>))'],
     'wp_is_uuid' => ['($version is 4|null ? bool : false)', 'uuid' => 'TUuid', 'version' => '4', '@phpstan-template TUuid' => 'of string', '@phpstan-assert-if-true' => '=TUuid&lowercase-string&non-falsy-string $uuid'],
     'wp_json_encode' => ['non-empty-string|false', 'depth' => 'int<1, max>'],

--- a/tests/data/wp_is_numeric_array.php
+++ b/tests/data/wp_is_numeric_array.php
@@ -7,6 +7,10 @@ namespace PhpStubs\WordPress\Core\Tests;
 use function wp_is_numeric_array;
 use function PHPStan\Testing\assertType;
 
+/*
+ * Check return type
+ */
+
 // No array
 assertType('false', wp_is_numeric_array(Faker::string()));
 assertType('false', wp_is_numeric_array(Faker::int()));
@@ -29,18 +33,69 @@ assertType('bool', wp_is_numeric_array(['value0', 'key1' => 'value1']));
 // Maybe array
 assertType('bool', wp_is_numeric_array(Faker::mixed()));
 
-// Test type specifying of wp_is_numeric_array
-$value = Faker::union(Faker::string(), Faker::list(Faker::string()));
-if (wp_is_numeric_array($value)) {
-    assertType('list<string>', $value);
+/*
+ * Check type specification
+ */
+
+// if wp_is_numeric_array, it must be a numeric array, therefore:
+$data = Faker::string();
+if (wp_is_numeric_array($data)) {
+    assertType('*NEVER*', $data);
+}
+// and:
+$data = Faker::strArray();
+if (wp_is_numeric_array($data)) {
+    assertType('*NEVER*', $data);
+}
+// and:
+$data = Faker::list(Faker::string());
+if (! wp_is_numeric_array($data)) {
+    assertType('*NEVER*', $data);
+}
+if (wp_is_numeric_array($data)) {
+    assertType('list<string>', $data);
+}
+// Check with mixed
+$data = Faker::mixed();
+if (wp_is_numeric_array($data)) {
+    assertType('array<int, mixed>', $data);
+}
+if (! wp_is_numeric_array($data)) {
+    assertType('mixed~(mixed is list ? list : array<int, mixed>)', $data);
 }
 
-$value = Faker::union(Faker::intArray(Faker::string()), Faker::string());
-if (wp_is_numeric_array($value)) {
-    assertType('array<int, string>', $value);
+// Check with indetermined array
+$data = Faker::array();
+if (wp_is_numeric_array($data)) {
+    assertType('array<int, mixed>', $data);
+}
+if (! wp_is_numeric_array($data)) {
+    assertType('array', $data); // can still be a mixed key array
 }
 
-$value = Faker::mixed();
-if (wp_is_numeric_array($value)) {
-    assertType('array<int, mixed>', $value);
+// Check with union
+$data = Faker::union(Faker::intArray(Faker::string()), Faker::string());
+if (wp_is_numeric_array($data)) {
+    assertType('array<int, string>', $data);
+}
+if (! wp_is_numeric_array($data)) {
+    assertType('string', $data);
+}
+
+// Check with constant values
+$data = Faker::union([1 => 'value1', 2 => 'value2'], ['value3', 'value4'], ['key' => 'value'], 'constant');
+if (wp_is_numeric_array($data)) {
+    assertType("array{'value3', 'value4'}|array{1: 'value1', 2: 'value2'}", $data);
+}
+if (! wp_is_numeric_array($data)) {
+    assertType("'constant'|array{key: 'value'}", $data);
+}
+
+// Check with mixed keys constant array
+$data = [1 => 'intKey', 'key' => 'stringKey'];
+if (wp_is_numeric_array($data)) {
+    assertType("non-empty-array<1, 'intKey'|'stringKey'>", $data);
+}
+if (! wp_is_numeric_array($data)) {
+    assertType("array{1: 'intKey', key: 'stringKey'}", $data);
 }


### PR DESCRIPTION
I also added more assertions for the `@phpstan-assert-if-true` tag, specifically to verify that types are not generalised. One case of generalisation occurs with constant arrays that have mixed keys. However, in practice this `if` condition will never evaluate to `true`:

```php
$data = [1 => 'intKey', 'key' => 'stringKey'];
if (wp_is_numeric_array($data)) {
    // unreachable
}
```