### PR TITLE
Narrow return type for wp_create_nonce()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -145,7 +145,7 @@ return [
     'wp_caption_input_textarea' => ['non-falsy-string'],
     'wp_clear_scheduled_hook' => ['(int<0, max>|($wp_error is false ? false : \WP_Error))', 'args' => $cronArgsType],
     'wp_count_terms' => ['numeric-string|\WP_Error'],
-    'wp_create_nonce' => [null, 'action' => '-1|string'],
+    'wp_create_nonce' => ['lowercase-string&non-falsy-string', 'action' => '-1|string'],
     'wp_cron' => ['false|int<0, max>|void'],
     'wp_debug_backtrace_summary' => ['($pretty is true ? string : list<string>)'],
     'wp_die' => ['($args is array{exit: false}&array ? void : never)'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -73,6 +73,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/validate_plugin.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_caption_input_textarea.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_count_terms.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_create_nonce.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_cron.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_debug_backtrace_summary.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_die.php');

--- a/tests/data/wp_create_nonce.php
+++ b/tests/data/wp_create_nonce.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_create_nonce;
+use function PHPStan\Testing\assertType;
+
+/*
+ * Check return type
+ */
+
+assertType('lowercase-string&non-falsy-string', wp_create_nonce(''));
+assertType('lowercase-string&non-falsy-string', wp_create_nonce('action'));
+assertType('lowercase-string&non-falsy-string', wp_create_nonce(Faker::string()));
+assertType('lowercase-string&non-falsy-string', wp_create_nonce(-1));


### PR DESCRIPTION
The function [`wp_create_nonce()`](https://developer.wordpress.org/reference/functions/wp_create_nonce/) returns a sub-string of `wp_hash()` and therefore returns `lowercase-string&non-falsy-string`.

#331 