### PR TITLE
Narrow return type of wp_internal_hosts()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -173,6 +173,7 @@ return [
     'wp_insert_category' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_insert_link' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_insert_post' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
+    'wp_internal_hosts' => ['array<lowercase-string>'],
     'wp_is_numeric_array' => ['(T is array<int, mixed> ? true : false)', '@phpstan-template' => 'T of mixed', 'data' => 'T', '@phpstan-assert-if-true' => '(T is list ? T : array<int, mixed>) $data'],
     'wp_is_post_revision' => ['($post is \WP_Post ? false|int<0, max> : ($post is int<min, 0> ? false : false|int<0, max>))'],
     'wp_is_uuid' => ['($version is 4|null ? bool : false)', 'uuid' => 'TUuid', 'version' => '4', '@phpstan-template TUuid' => 'of string', '@phpstan-assert-if-true' => '=TUuid&lowercase-string&non-falsy-string $uuid'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -94,6 +94,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_get_speculation_rules_configuration.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_hash.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_http_validate_url.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_internal_hosts.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_is_numeric_array.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_is_post_revision.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_is_uuid.php');

--- a/tests/data/wp_internal_hosts.php
+++ b/tests/data/wp_internal_hosts.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_internal_hosts;
+use function PHPStan\Testing\assertType;
+
+assertType('array<lowercase-string>', wp_internal_hosts());


### PR DESCRIPTION
The function [`wp_internal_hosts()`](https://developer.wordpress.org/reference/functions/wp_internal_hosts/) returns the result of `array_unique(array_map('strtolower', (array) $internal_hosts))` which has the type `array<lowercase-string>`.