### PR TITLE
Add cond. return type and type narrowing for taxonomy_exists

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -133,6 +133,7 @@ return [
     'stripslashes_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'stripslashes_from_strings_only' => ["(\$value is string ? (\$value is '' ? '' : string) : T)", '@phpstan-template' => 'T', 'value' => 'T|string'],
     'tag_exists' => ["(\$tag_name is 0 ? 0 : (\$tag_name is '' ? null : array{term_id: string, term_taxonomy_id: string}|null))"],
+    'taxonomy_exists' => ['($taxonomy is non-falsy-string ? bool : false)', '@phpstan-impure' => '', '@phpstan-assert-if-true' => '=non-falsy-string $taxonomy'],
     'term_exists' => ["(\$term is 0 ? 0 : (\$term is '' ? null : (\$taxonomy is '' ? string|null : array{term_id: string, term_taxonomy_id: string}|null)))"],
     'the_date' => ['($display is true ? void : string)'],
     'the_modified_date' => ['($display is true ? void : string)'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -67,6 +67,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/sanitize_title_with_dashes.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/size_format.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/stripslashes.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/taxonomy_exists.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/trailingslashit.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/validate_file.php');

--- a/tests/data/taxonomy_exists.php
+++ b/tests/data/taxonomy_exists.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function taxonomy_exists;
+use function PHPStan\Testing\assertType;
+
+/*
+ * Check return type
+ */
+
+assertType('false', taxonomy_exists(''));
+assertType('false', taxonomy_exists('0'));
+assertType('bool', taxonomy_exists('tax'));
+assertType('bool', taxonomy_exists(Faker::string()));
+assertType('bool', taxonomy_exists(Faker::nonEmptyString()));
+assertType('bool', taxonomy_exists(Faker::nonFalsyString()));
+
+/*
+ * Check impurity
+ */
+
+if (taxonomy_exists('taxonomy')) {
+    assertType('bool', taxonomy_exists('taxonomy'));
+}
+if (! taxonomy_exists('taxonomy')) {
+    assertType('bool', taxonomy_exists('taxonomy'));
+}
+
+$taxonomy = Faker::string();
+if (taxonomy_exists($taxonomy)) {
+    assertType('bool', taxonomy_exists($taxonomy));
+}
+if (! taxonomy_exists($taxonomy)) {
+    assertType('bool', taxonomy_exists($taxonomy));
+}
+
+/*
+ * Check type specification
+ */
+
+$taxonomy = Faker::string();
+if (taxonomy_exists($taxonomy)) {
+    assertType('non-falsy-string', $taxonomy);
+}
+if (! taxonomy_exists($taxonomy)) {
+    assertType('string', $taxonomy);
+}


### PR DESCRIPTION
The function [`taxonomy_exists($taxonomy)`](https://developer.wordpress.org/reference/functions/taxonomy_exists/) returns `true` if a taxonomy named `$taxonomy` exists. The name of any taxonomy must be a `non-falsy-string` (see [`register_taxonomy()`](https://developer.wordpress.org/reference/functions/register_taxonomy/)).

- Falsy strings will always result in `taxonomy_exists()` returning `false`.
- If it returns `true`, the taxonomy exists and `$taxonomy` must therefore be a `non-falsy-string`.
- `taxonomy_exists()` depends on database state and is therefore impure (see https://github.com/szepeviktor/phpstan-wordpress/issues/274#issuecomment-3197883397). 

Therefore, this PR adds
- a conditional return type,
- a `@phpstan-assert-if-true` tag (with `=` to prevent PHPStan’s automatic assumptions about `false`),
- a `@phpstan-impure` tag.

Note: although the function reference for `register_taxonomy()` mentions lowercase for taxonomy names, this is not part of this PR; it is possible to register taxonomies with a name containing `A-Z`.
