### PR TITLE
Fix conditional return type for wp_insert_link()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -172,7 +172,7 @@ return [
     'wp_http_validate_url' => ["(TUrl is numeric|'' ? false : TUrl|false)", '@phpstan-template TUrl' => 'of string', 'url' => 'TUrl'],
     'wp_insert_attachment' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_insert_category' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
-    'wp_insert_link' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
+    'wp_insert_link' => ['($wp_error is false ? int<0, max> : int<0, max>|\WP_Error)'],
     'wp_insert_post' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_internal_hosts' => ['array<lowercase-string>'],
     'wp_is_numeric_array' => ['(T is array<int, mixed> ? true : false)', '@phpstan-template' => 'T of mixed', 'data' => 'T', '@phpstan-assert-if-true' => '(T is list ? T : array<int, mixed>) $data'],

--- a/tests/data/wp_error_parameter.php
+++ b/tests/data/wp_error_parameter.php
@@ -24,7 +24,7 @@ use function PHPStan\Testing\assertType;
  */
 assertType('int<0, max>', wp_insert_link([]));
 assertType('int<0, max>', wp_insert_link([], false));
-assertType('int<1, max>|WP_Error', wp_insert_link([], true));
+assertType('int<0, max>|WP_Error', wp_insert_link([], true));
 assertType('int<0, max>|WP_Error', wp_insert_link([], Faker::bool()));
 
 /*


### PR DESCRIPTION
For `$linkdata['link_name'] = ''` and  `$linkdata['link_url'] = ''` `wp_insert_link()` returns `0` even if `$wp_post = false`. See [lines 196-206 in bookmark.php](https://github.com/WordPress/wordpress-develop/blob/c726220a21d13fdb5409372b652c9460c59ce1db/src/wp-admin/includes/bookmark.php#L196-L206).