### PR TITLE
Narrow return type for wp_update_category()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -215,6 +215,7 @@ return [
     'wp_unschedule_event' => ['($wp_error is false ? bool : true|\WP_Error)', 'args' => $cronArgsType],
     'wp_unschedule_hook' => ['($wp_error is false ? int<0, max>|false : int<0, max>|\WP_Error)'],
     'wp_unslash' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
+    'wp_update_category' => ['int<0, max>|false'],
     'wp_update_comment' => ['($wp_error is false ? 0|1|false : 0|1|\WP_Error)'],
     'wp_update_post' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_verify_nonce' => ['1|2|false', 'action' => '-1|string'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -112,6 +112,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_theme.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_translations.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_unique_id.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_update_category.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_widget_factory.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_widget_rss.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_widgets_access_body_class.php');

--- a/tests/data/wp_update_category.php
+++ b/tests/data/wp_update_category.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function wp_update_category;
+use function PHPStan\Testing\assertType;
+
+assertType('int<0, max>|false', wp_update_category([]));
+assertType('int<0, max>|false', wp_update_category(['cat_ID' => 123]));
+assertType('int<0, max>|false', wp_update_category(Faker::array()));


### PR DESCRIPTION
The function [`wp_update_category()`](https://developer.wordpress.org/reference/functions/wp_update_category/) returns:
> The ID number of the new or updated Category on success. Zero or FALSE on failure.