### PR TITLE
Add conditional return type and narrow argument type for has_shortcode()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -107,6 +107,7 @@ return [
     'get_user_by' => ["(\$field is 'id'|'ID' ? (\$value is int<min, 0> ? false : \WP_User|false) : \WP_User|false)"],
     'has_action' => ['($callback is false ? bool : false|int)'],
     'has_filter' => ['($callback is false ? bool : false|int)'],
+    'has_shortcode' => ['($tag is empty ? false : ($content is empty ? false : bool))', '@phpstan-assert-if-true =non-falsy-string $content' => '', '@phpstan-assert-if-true =non-empty-string $tag' => ''],
     'have_posts' => [null, '@phpstan-impure' => ''],
     'image_link_input_fields' => ['non-falsy-string'],
     'image_size_input_fields' => ["array{label: string, input: 'html', html: string}"],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -53,6 +53,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_user.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_user_by.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/has_filter.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/has_shortcode.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/have_posts.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/image_link_input_fields.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/image_size_input_fields.php');

--- a/tests/data/has_shortcode.php
+++ b/tests/data/has_shortcode.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function PHPStan\Testing\assertType;
+
+/*
+ * Check return type
+ */
+
+assertType('false', has_shortcode('', ''));
+assertType('false', has_shortcode('', 'foo'));
+assertType('false', has_shortcode('foo', ''));
+assertType('bool', has_shortcode('foo', 'foo'));
+
+assertType('false', has_shortcode('', ''));
+assertType('false', has_shortcode('', Faker::string()));
+assertType('false', has_shortcode(Faker::string(), ''));
+assertType('bool', has_shortcode(Faker::string(), Faker::string()));
+
+/*
+ * Check argument type
+ */
+
+$content = Faker::string();
+$tag = Faker::string();
+if (has_shortcode($content, $tag)) {
+    assertType('non-falsy-string', $content);
+    assertType('non-empty-string', $tag);
+}
+assertType('string', $content);
+assertType('string', $tag);
+
+// Check that types are not generalized
+$content = 'content';
+$tag = 'tag';
+if (has_shortcode($content, $tag)) {
+    assertType("'content'", $content);
+    assertType("'tag'", $tag);
+}


### PR DESCRIPTION
- If either `$tag` or `$content` is `''` the function `has_shortcode()` always returns `false`.
- If `has_shortcode()` returns `true`, `$content` must be a `non-falsy-string` (it at least contains `[tagName]`) and `$tag` must be a `non-empty-string` (a valid tag name cannot be empty).