### PR TITLE
Narrow return type of wp_html_split()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -178,6 +178,7 @@ return [
     'wp_get_server_protocol' => ["'HTTP/1.0'|'HTTP/1.1'|'HTTP/2'|'HTTP/2.0'|'HTTP/3'"],
     'wp_get_speculation_rules_configuration' => ["array{mode: 'prefetch'|'prerender', eagerness: 'conservative'|'eager'|'moderate'}|null"],
     'wp_hash' => ['lowercase-string&non-falsy-string', 'scheme' => "'auth'|'logged_in'|'nonce'|'secure_auth'"],
+    'wp_html_split' => ['non-empty-list<string>'],
     'wp_http_validate_url' => ["(TUrl is numeric|'' ? false : TUrl|false)", '@phpstan-template TUrl' => 'of string', 'url' => 'TUrl'],
     'wp_insert_attachment' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],
     'wp_insert_category' => ['($wp_error is false ? int<0, max> : int<1, max>|\WP_Error)'],

--- a/tests/TypeInferenceTest.php
+++ b/tests/TypeInferenceTest.php
@@ -41,7 +41,6 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_pagination_arrow.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_permalink.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_plugin_page_hookname.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_regex.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_password_reset_key.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_site_screen_help.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_sites.php');
@@ -63,6 +62,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql2date.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/paginate_links.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/prep_atom_text_construct.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/regex.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/rest_authorization_required_code.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/rest_ensure_response.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/rest_sanitize_boolean.php');

--- a/tests/data/regex.php
+++ b/tests/data/regex.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace PhpStubs\WordPress\Core\Tests;
 
+use function get_html_split_regex;
 use function get_shortcode_regex;
 use function get_shortcode_atts_regex;
 use function get_tag_regex;
+use function wp_html_split;
 use function PHPStan\Testing\assertType;
 
 assertType('non-falsy-string', get_shortcode_regex());
@@ -17,3 +19,5 @@ assertType('non-falsy-string', get_shortcode_atts_regex());
 assertType('non-falsy-string', get_tag_regex(Faker::string()));
 
 assertType('non-falsy-string', get_html_split_regex());
+
+assertType('non-empty-list<string>', wp_html_split(Faker::string()));


### PR DESCRIPTION
[`wp_html_split()`](https://developer.wordpress.org/reference/functions/wp_html_split/) may return `['']` but not `[]` → narrowed from `string[]` to `non-empty-list<string>`.