### PR TITLE
Mark bool_from_yn, absint, and block_version as pure

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -53,7 +53,7 @@ return [
     'add_theme_page' => [null, 'callback' => "''|callable"],
     'add_users_page' => [null, 'callback' => "''|callable"],
     'addslashes_gpc' => ['T', '@phpstan-template' => 'T', 'gpc' => 'T'],
-    'block_version' => ["(\$content is '' ? 0 : 0|1)"],
+    'block_version' => ["(\$content is '' ? 0 : 0|1)", '@phpstan-pure' => ''],
     'bool_from_yn' => ["(\$yn is 'y' ? true : false)", '@phpstan-pure' => ''],
     'build_dropdown_script_block_core_categories' => ['non-falsy-string'],
     'check_admin_referer' => ['1|2|false', 'action' => '-1|string'],

--- a/functionMap.php
+++ b/functionMap.php
@@ -54,7 +54,7 @@ return [
     'add_users_page' => [null, 'callback' => "''|callable"],
     'addslashes_gpc' => ['T', '@phpstan-template' => 'T', 'gpc' => 'T'],
     'block_version' => ["(\$content is '' ? 0 : 0|1)"],
-    'bool_from_yn' => ["(\$yn is 'y' ? true : false)"],
+    'bool_from_yn' => ["(\$yn is 'y' ? true : false)", '@phpstan-pure' => ''],
     'build_dropdown_script_block_core_categories' => ['non-falsy-string'],
     'check_admin_referer' => ['1|2|false', 'action' => '-1|string'],
     'check_ajax_referer' => ['1|2|false', 'action' => '-1|string'],

--- a/functionMap.php
+++ b/functionMap.php
@@ -37,7 +37,7 @@ return [
     '__return_empty_string' => ["''"],
     '__return_zero' => ['0'],
     '_get_list_table' => ["(\$class_name is 'WP_Posts_List_Table'|'WP_Media_List_Table'|'WP_Terms_List_Table'|'WP_Users_List_Table'|'WP_Comments_List_Table'|'WP_Post_Comments_List_Table'|'WP_Links_List_Table'|'WP_Plugin_Install_List_Table'|'WP_Themes_List_Table'|'WP_Theme_Install_List_Table'|'WP_Plugins_List_Table'|'WP_Application_Passwords_List_Table'|'WP_MS_Sites_List_Table'|'WP_MS_Users_List_Table'|'WP_MS_Themes_List_Table'|'WP_Privacy_Data_Export_Requests_List_Table'|'WP_Privacy_Data_Removal_Requests_List_Table' ? new<T> : false)", '@phpstan-template T' => 'of string', 'class_name' => 'T', 'args' => 'array{screen?: string}'],
-    'absint' => ['($maybeint is T&int<0, max> ? T : ($maybeint is int<min, -1> ? int<1, max> : ($maybeint is empty ? 0 : ($maybeint is numeric-string ? int<0, max> : ($maybeint is string ? 0 : ($maybeint is true|non-empty-array ? 1 : ($maybeint is bool ? 0|1 : int<0, max>)))))))', '@phpstan-template T' => 'of int', 'maybeint' => 'T|scalar|array|resource|null'],
+    'absint' => ['($maybeint is T&int<0, max> ? T : ($maybeint is int<min, -1> ? int<1, max> : ($maybeint is empty ? 0 : ($maybeint is numeric-string ? int<0, max> : ($maybeint is string ? 0 : ($maybeint is true|non-empty-array ? 1 : ($maybeint is bool ? 0|1 : int<0, max>)))))))', '@phpstan-template T' => 'of int', 'maybeint' => 'T|scalar|array|resource|null', '@phpstan-pure' => ''],
     'add_comments_page' => [null, 'callback' => "''|callable"],
     'add_dashboard_page' => [null, 'callback' => "''|callable"],
     'add_link' => ['int<0, max>'],

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,6 +18,7 @@
     </rule>
     <rule ref="SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable">
         <exclude-pattern>tests/data/param/wpdb.php</exclude-pattern>
+        <exclude-pattern>tests/data/param/absint.php</exclude-pattern>
     </rule>
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
         <exclude-pattern>tests/data/**/__demo.php</exclude-pattern>

--- a/tests/data/param/absint.php
+++ b/tests/data/param/absint.php
@@ -7,10 +7,10 @@ namespace PhpStubs\WordPress\Core\Tests;
 use stdClass;
 use function absint;
 
-absint(Faker::scalar()); // correct
-absint(Faker::array()); // correct
-absint(null); // correct
-absint('constantString'); // correct
+$result = absint(Faker::scalar()); // correct
+$result = absint(Faker::array()); // correct
+$result = absint(null); // correct
+$result = absint('constantString'); // correct
 
-absint(Faker::object()); // incorrect
-absint(new stdClass()); // incorrect
+$result = absint(Faker::object()); // incorrect
+$result = absint(new stdClass()); // incorrect

--- a/tests/data/pure/absint.php
+++ b/tests/data/pure/absint.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function absint;
+use function PHPStan\Testing\assertType;
+
+$intArg = Faker::int();
+
+assertType('int<0, max>', absint($intArg));
+
+if (absint($intArg) === 1) {
+    assertType('1', absint($intArg));
+}
+
+if (absint($intArg) > 1) {
+    assertType('int<2, max>', absint($intArg));
+}

--- a/tests/data/pure/block_version.php
+++ b/tests/data/pure/block_version.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function block_version;
+use function PHPStan\Testing\assertType;
+
+$content = Faker::string();
+
+assertType('0|1', block_version($content));
+
+if (block_version($content) === 1) {
+    assertType('1', block_version($content));
+}
+
+if (block_version($content) === 0) {
+    assertType('0', block_version($content));
+}

--- a/tests/data/pure/bool_from_yn.php
+++ b/tests/data/pure/bool_from_yn.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function bool_from_yn;
+use function PHPStan\Testing\assertType;
+
+$strArg = Faker::string();
+
+assertType('bool', bool_from_yn($strArg));
+
+if (bool_from_yn($strArg) === true) {
+    assertType('true', bool_from_yn($strArg));
+}
+
+if (bool_from_yn($strArg) === false) {
+    assertType('false', bool_from_yn($strArg));
+}
+
+if (bool_from_yn($strArg) !== true) {
+    assertType('false', bool_from_yn($strArg));
+}


### PR DESCRIPTION
These functions have no side effects and each function’s output depends only on its arguments.

- https://developer.wordpress.org/reference/functions/bool_from_yn/
- https://developer.wordpress.org/reference/functions/absint/
- https://developer.wordpress.org/reference/functions/block_version/

For pure functions, PHPStan reports `Call to function functionName() on a separate line has no effect.` when the function's return value is unused. Therefore, an assignment has been added to the calls in `tests/data/param/absint.php`.