### PR TITLE
Fix return type of addslashes_gpc and mark it as pure

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -53,7 +53,7 @@ return [
     'add_submenu_page' => [null, 'callback' => "''|callable"],
     'add_theme_page' => [null, 'callback' => "''|callable"],
     'add_users_page' => [null, 'callback' => "''|callable"],
-    'addslashes_gpc' => ['T', '@phpstan-template' => 'T', 'gpc' => 'T'],
+    'addslashes_gpc' => ['($gpc is string ? string : array)', '@phpstan-pure' => ''],
     'block_version' => ["(\$content is '' ? 0 : 0|1)", '@phpstan-pure' => ''],
     'bool_from_yn' => ["(\$yn is 'y' ? true : false)", '@phpstan-pure' => ''],
     'build_dropdown_script_block_core_categories' => ['non-falsy-string'],

--- a/tests/data/pure/addslashes-gpc.php
+++ b/tests/data/pure/addslashes-gpc.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function addslashes_gpc;
+use function PHPStan\Testing\assertType;
+
+$gpc = Faker::string();
+if (addslashes_gpc($gpc) === 'foo') {
+    assertType("'foo'", addslashes_gpc($gpc));
+}
+
+$gpc = Faker::array();
+if (addslashes_gpc($gpc) === ['foo' => 'bar']) {
+    assertType("array{foo: 'bar'}", addslashes_gpc($gpc));
+}

--- a/tests/data/return/addslashes_gpc.php
+++ b/tests/data/return/addslashes_gpc.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function addslashes_gpc;
+use function PHPStan\Testing\assertType;
+
+assertType('string', addslashes_gpc(''));
+assertType('string', addslashes_gpc('value'));
+assertType('string', addslashes_gpc(Faker::nonEmptyString()));
+assertType('string', addslashes_gpc(Faker::string()));
+
+assertType('array', addslashes_gpc([]));
+assertType('array', addslashes_gpc(['key' => 'value']));
+assertType('array', addslashes_gpc(Faker::nonEmptyArray()));
+assertType('array', addslashes_gpc(Faker::array()));


### PR DESCRIPTION
See issue #333

Related:
- https://github.com/szepeviktor/phpstan-wordpress/pull/296
- #369