### PR TITLE
Narrow return type of get_post_ancestors

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -86,6 +86,7 @@ return [
     'get_password_reset_key' => [null, '@phpstan-impure' => ''],
     'get_permalink' => ['($post is \WP_Post ? string : string|false)'],
     'get_post' => ["(\$post is \WP_Post ? array<array-key, mixed>|\WP_Post : array<array-key, mixed>|\WP_Post|null) & (\$output is 'ARRAY_A' ? array<string, mixed>|null : (\$output is 'ARRAY_N' ? array<int, mixed>|null : \WP_Post|null))", 'output' => "'OBJECT'|'ARRAY_A'|'ARRAY_N'" ],
+    'get_post_ancestors' => ['list<int>'],
     'get_post_permalink' => ['($post is \WP_Post ? string : string|false)'],
     'get_post_stati' => ["(\$output is 'names' ? array<string, string> : array<string, \stdClass>)"],
     'get_post_types' => ["(\$output is 'names' ? array<string, string> : array<string, \WP_Post_Type>)"],

--- a/tests/data/return/get-post-ancestors.php
+++ b/tests/data/return/get-post-ancestors.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function get_post_ancestors;
+use function PHPStan\Testing\assertType;
+
+assertType('list<int>', get_post_ancestors(123));
+assertType('list<int>', get_post_ancestors(Faker::int()));
+assertType('list<int>', get_post_ancestors(Faker::wpPost()));


### PR DESCRIPTION
Narrows the return type of [`get_post_ancestors()`](https://developer.wordpress.org/reference/functions/get_post_ancestors/) from `int[]` to `list<int>`.

Starting from an empty array, the returned array is built by adding ancestors using `$ancestors[] = $id`; therefore it is a list.
