### PR TITLE
Narrow parameter type for register_post_type

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -126,6 +126,7 @@ return [
     'previous_posts' => ['($display is true ? void : string)'],
     'rawurlencode_deep' => ['T', '@phpstan-template' => 'T', 'value' => 'T'],
     'register_nav_menus' => [null, 'locations' => 'array<string, string>'],
+    'register_post_type' => [null, 'post_type' => 'lowercase-string&non-empty-string'],
     'render_block_core_categories' => ['non-falsy-string'],
     'rest_authorization_required_code' => ['401|403'],
     'rest_sanitize_boolean' => ["(T is bool ? T : (T is ''|'false'|'FALSE'|'0'|0 ? false : true))", '@phpstan-template T' => 'of bool|string|int', 'value' => 'T'],

--- a/tests/ParameterTypeTest.php
+++ b/tests/ParameterTypeTest.php
@@ -117,6 +117,22 @@ class ParameterTypeTest extends IntegrationTest
         );
     }
 
+    public function testRegisterPostType(): void
+    {
+        $this->analyse(
+            __DIR__ . '/data/param/register-post-type.php',
+            [
+                ["Parameter #1 \$post_type of function register_post_type expects lowercase-string&non-empty-string, '' given.", 13],
+                ["Parameter #1 \$post_type of function register_post_type expects lowercase-string&non-empty-string, 'PostType' given.", 14],
+                // Maybes
+                ['Parameter #1 $post_type of function register_post_type expects lowercase-string&non-empty-string, non-empty-string given.', 17],
+                ['Parameter #1 $post_type of function register_post_type expects lowercase-string&non-empty-string, non-falsy-string given.', 18],
+                ['Parameter #1 $post_type of function register_post_type expects lowercase-string&non-empty-string, lowercase-string given.', 19],
+                ['Parameter #1 $post_type of function register_post_type expects lowercase-string&non-empty-string, string given.', 20],
+            ]
+        );
+    }
+
     public function testWpdbGetRow(): void
     {
         $this->analyse(

--- a/tests/data/param/register-post-type.php
+++ b/tests/data/param/register-post-type.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function register_post_type;
+
+$empty = '';
+$containsUppercases = 'PostType';
+
+// Incorrect $post_type
+register_post_type($empty, Faker::array());
+register_post_type($containsUppercases, Faker::array());
+
+// Maybe incorrect $post_type
+register_post_type(Faker::nonEmptyString(), Faker::array());
+register_post_type(Faker::nonFalsyString(), Faker::array());
+register_post_type(Faker::lowercaseString(), Faker::array());
+register_post_type(Faker::string(), Faker::array());
+
+// Correct $post_type
+register_post_type('post_type', Faker::array());
+register_post_type(Faker::intersection(Faker::lowercaseString(), Faker::nonEmptyString()), Faker::array());


### PR DESCRIPTION
Narrows the `$post_type` parameter of [`register_post_type()`](https://developer.wordpress.org/reference/functions/register_post_type/#source) as it

> may only contain lowercase alphanumeric characters, dashes, and underscores

and triggers `_doing_it_wrong()` in such cases or if empty.