### PR TITLE
Fix return type of sanitize_post

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -133,7 +133,7 @@ return [
     'rest_ensure_response' => ['($response is \WP_Error ? \WP_Error : \WP_REST_Response)'],
     'sanitize_bookmark_field' => ['array<int, int>|int|string', 'field' => "'link_id'|'link_url'|'link_name'|'link_image'|'link_target'|'link_description'|'link_visible'|'link_owner'|'link_rating'|'link_updated'|'link_rel'|'link_notes'|'link_rss'|'link_category'"],
     'sanitize_category' => ['T', '@phpstan-template' => 'T of array|object', 'category' => 'T'],
-    'sanitize_post' => ['T', '@phpstan-template' => 'T of array|object', 'post' => 'T'],
+    'sanitize_post' => ['(T is \WP_Post ? \WP_Post : (T is object ? object : (T is array ? array : T)))', '@phpstan-template T' => 'of mixed', 'post' => 'T'],
     'sanitize_sql_orderby' => ['(T is non-falsy-string ? T|false : false)', '@phpstan-template T' => 'of string', 'orderby' => 'T'],
     'sanitize_term' => ['T', '@phpstan-template' => 'T of array|object', 'term' => 'T'],
     'sanitize_title_with_dashes' => ['lowercase-string', 'context' => "'display'|'save'"],

--- a/tests/data/return/sanitize-post.php
+++ b/tests/data/return/sanitize-post.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use stdClass;
+
+use function sanitize_post;
+use function PHPStan\Testing\assertType;
+
+assertType('WP_Post', sanitize_post(Faker::wpPost(), Faker::string()));
+assertType('object', sanitize_post(Faker::object(), Faker::string()));
+assertType('object', sanitize_post(new stdClass(), Faker::string()));
+assertType('array', sanitize_post(Faker::array(), Faker::string()));
+assertType('array', sanitize_post(Faker::strArray(), Faker::string()));
+assertType('array', sanitize_post(Faker::intArray(), Faker::string()));
+assertType('array', sanitize_post(Faker::array(Faker::string()), Faker::string()));
+
+// Incorrect type of $post is returned as-is.
+assertType("'foo'", sanitize_post('foo', Faker::string()));
+assertType('123', sanitize_post(123, Faker::string()));
+assertType('string', sanitize_post(Faker::string(), Faker::string()));
+assertType('int', sanitize_post(Faker::int(), Faker::string()));
+assertType('bool', sanitize_post(Faker::bool(), Faker::string()));


### PR DESCRIPTION
See issue #333

Unfortunately, we're losing a lot of type information. However, I think that both [`sanitize_post()`](https://developer.wordpress.org/reference/functions/sanitize_post/) and [`sanitize_post_field()`](https://developer.wordpress.org/reference/functions/sanitize_post_field/) are too complex to be handled via stubs and require return type extensions. `sanitize_post_field()` would also greatly benefit from a rule checking arguments.