### PR TITLE
Narrow argument type for shortcode_exists

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -139,6 +139,7 @@ return [
     'sanitize_term' => ['T', '@phpstan-template' => 'T of array|object', 'term' => 'T'],
     'sanitize_term_field' => ["(\$field is 'parent'|'term_id'|'count'|'term_group'|'term_taxonomy_id'|'object_id' ? int<0, max> : (\$context is 'raw' ? T : (\$context is 'attribute'|'edit'|'js' ? string : mixed)))", '@phpstan-template T' => 'of string', 'value' => 'T'],
     'sanitize_title_with_dashes' => ['lowercase-string', 'context' => "'display'|'save'"],
+    'shortcode_exists' => [null, '@phpstan-assert-if-true' => '=non-empty-string $tag'],
     'single_cat_title' => ['($display is true ? void : string|void)'],
     'single_month_title' => ['($display is true ? false|void : false|string)'],
     'single_post_title' => ['($display is true ? void : string|void)'],

--- a/tests/data/assert/shortcode-exists.php
+++ b/tests/data/assert/shortcode-exists.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function shortcode_exists;
+use function PHPStan\Testing\assertType;
+
+$tag = Faker::string();
+if (shortcode_exists($tag)) {
+    assertType('non-empty-string', $tag);
+}
+if (! shortcode_exists($tag)) {
+    assertType('string', $tag);
+}
+
+// Check that constant strings are not generalized
+$tag = 'tag';
+if (shortcode_exists($tag)) {
+    assertType("'tag'", $tag);
+}


### PR DESCRIPTION
If [`shortcode_exists($tag)`](https://developer.wordpress.org/reference/functions/shortcode_exists/) returns `true`, the given `$tag` must be a valid shortcode tag. A valid shortcode tag is a `non-empty-string`. Because `'0'` is permitted as a shortcode tag, a valid shortcode tag is not necessarily a `non-falsy-string`.
