### PR TITLE
Narrow parameter type for antispambot()

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -54,6 +54,7 @@ return [
     'add_theme_page' => [null, 'callback' => "''|callable"],
     'add_users_page' => [null, 'callback' => "''|callable"],
     'addslashes_gpc' => ['($gpc is string ? string : array)', '@phpstan-pure' => ''],
+    'antispambot' => [null, 'hex_encoding' => '0|1'],
     'block_version' => ["(\$content is '' ? 0 : 0|1)", '@phpstan-pure' => ''],
     'bool_from_yn' => ["(\$yn is 'y' ? true : false)", '@phpstan-pure' => ''],
     'build_dropdown_script_block_core_categories' => ['non-falsy-string'],

--- a/tests/ParameterTypeTest.php
+++ b/tests/ParameterTypeTest.php
@@ -63,6 +63,20 @@ class ParameterTypeTest extends IntegrationTest
         );
     }
 
+    public function testAntispambot(): void
+    {
+        $this->analyse(
+            __DIR__ . '/data/param/antispambot.php',
+            [
+                ['Parameter #2 $hex_encoding of function antispambot expects 0|1, 42 given.', 12],
+                ['Parameter #2 $hex_encoding of function antispambot expects 0|1, -42 given.', 13],
+                ['Parameter #2 $hex_encoding of function antispambot expects 0|1, string given.', 14],
+                // Maybes
+                ['Parameter #2 $hex_encoding of function antispambot expects 0|1, int given.', 17],
+            ]
+        );
+    }
+
     public function testBookmarks(): void
     {
         $field = "'link_category'|'link_description'|'link_id'|'link_image'|'link_name'|'link_notes'|'link_owner'|'link_rating'|'link_rel'|'link_rss'|'link_target'|'link_updated'|'link_url'|'link_visible'";

--- a/tests/data/param/antispambot.php
+++ b/tests/data/param/antispambot.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function antispambot;
+
+$email = Faker::string();
+
+// Incorrect $hex_encoding
+antispambot($email, 42);
+antispambot($email, -42);
+antispambot($email, Faker::string());
+
+// Maybe incorrect $hex_encoding
+antispambot($email, Faker::int());
+
+// Correct $hex_encoding
+antispambot($email, 0);
+antispambot($email, 1);


### PR DESCRIPTION
Narrows `$hex_encoding` from `int` to `0|1` for [`antispambot()`](https://developer.wordpress.org/reference/functions/antispambot/).

While passing integers other than `0` (default) or `1` does not trigger PHP or WordPress errors, it expands the random range `rand(0, 1 + $hex_encoding)`, allowing values (e.g. `3`) that hit no branch and therefore omit characters. `-1` would preserve correct email addresses, but since the parameter description says:

> Set to 1 to enable hex encoding.

it has been narrowed to `0|1`.