### PR TITLE
Fix type expectation in ! wp_is_numeric_array() scope

### DIFF
--- a/tests/data/assert/wp-is-numeric-array.php
+++ b/tests/data/assert/wp-is-numeric-array.php
@@ -40,7 +40,7 @@ if (wp_is_numeric_array($data)) {
     assertType('array<int, mixed>', $data);
 }
 if (! wp_is_numeric_array($data)) {
-    assertType('array', $data); // can still be a mixed key array
+    assertType('non-empty-array', $data); // can still be a mixed key array
 }
 
 // Check with union


### PR DESCRIPTION
An empty array is considered a numeric array. Since PHPStan 2.1.23, this is accounted for, so inside `if (! wp_is_numeric_array($data))` PHPStan correctly infers `$data` as a `non-empty-array`: an empty array would make `wp_is_numeric_array($data)` return `true` and therefore cannot reach the negated branch.

Related:
- https://github.com/phpstan/phpstan/issues/9734
- https://github.com/phpstan/phpstan-src/pull/4225