### PR TITLE
Skip adding return tags to void-returning magic methods

### DIFF
--- a/src/Visitor.php
+++ b/src/Visitor.php
@@ -814,6 +814,25 @@ class Visitor extends NodeVisitor
             return null;
         }
 
+        if (
+            $node instanceof ClassMethod
+            && in_array(
+                strtolower($node->name->name),
+                [
+                    '__clone',
+                    '__construct',
+                    '__destruct',
+                    '__set',
+                    '__unserialize',
+                    '__unset',
+                    '__wakeup',
+                ],
+                true
+            )
+        ) {
+            return null;
+        }
+
         $returnStmts = $this->nodeFinder->findInstanceOf($node, Stmt_Return::class);
 
         // If there is a return statement, it's not return type never.


### PR DESCRIPTION
PHPStan understands built-in PHP magic methods, so the following methods do not need an additional return tag:

- `__construct`
- `__destruct`
- `__clone`
- `__set`
- `__unset`
- `__wakeup`
- `__unserialize`

Skipping the automatic generation of `@phpstan-return void` reduces noise in the generated stubs.

