### PR TITLE
Don't generate a `@phpstan-return` tag when one already exists.

### DIFF
--- a/src/Visitor.php
+++ b/src/Visitor.php
@@ -223,6 +223,9 @@ class Visitor extends NodeVisitor
         /** @var list<\phpDocumentor\Reflection\DocBlock\Tags\Return_> $returnTags */
         $returnTags = $docblock->getTagsByName('return');
 
+        /** @var list<\phpDocumentor\Reflection\DocBlock\Tag> $phpStanReturnTags */
+        $phpStanReturnTags = $docblock->getTagsByName('phpstan-return');
+
         /** @var list<\phpDocumentor\Reflection\DocBlock\Tags\Var_> $varTags */
         $varTags = $docblock->getTagsByName('var');
 
@@ -243,14 +246,16 @@ class Visitor extends NodeVisitor
             $additions[] = $addition;
         }
 
-        foreach ($returnTags as $returnTag) {
-            $addition = self::getAdditionFromReturn($returnTag);
+        if (! count($phpStanReturnTags)) {
+            foreach ($returnTags as $returnTag) {
+                $addition = self::getAdditionFromReturn($returnTag);
 
-            if (! ($addition instanceof WordPressTag)) {
-                continue;
+                if (! ($addition instanceof WordPressTag)) {
+                    continue;
+                }
+
+                $additions[] = $addition;
             }
-
-            $additions[] = $addition;
         }
 
         foreach ($varTags as $varTag) {

--- a/tests/VisitorTest.php
+++ b/tests/VisitorTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use PhpStubs\WordPress\Core\Visitor;
+use PHPUnit\Framework\TestCase;
+use StubsGenerator\Result;
+use StubsGenerator\StubsGenerator;
+
+final class VisitorTest extends TestCase
+{
+    /**
+     * Generates stub output for a snippet of PHP source using the WordPress stubs Visitor.
+     *
+     * Symbols are only emitted if they are not already declared, so snippets must use
+     * function names that do not exist in the generated `wordpress-stubs.php` (which the
+     * PHPStan-based tests load into the process).
+     */
+    private static function generateStubs(string $code): string
+    {
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+
+        $visitor = new Visitor();
+        $visitor->init(StubsGenerator::ALL);
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
+        $traverser->addVisitor($visitor);
+
+        $stmts = $parser->parse($code);
+        self::assertNotNull($stmts);
+        $traverser->traverse($stmts);
+
+        return (new Result($visitor, []))->prettyPrint();
+    }
+
+    /**
+     * An existing `@phpstan-return` in the source docblock must be preserved as the only instance.
+     */
+    public function testHandWrittenPhpStanReturnIsNotDuplicated(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        /**
+         * @return array|null {
+         *     @type string $name Name.
+         *     @type string $type Type.
+         * }
+         * @phpstan-return ?array{name: non-empty-string, type: non-empty-string}
+         */
+        function wpstubs_test_connector_with_phpstan_return( string $id ): ?array {
+            return null;
+        }
+        PHP;
+
+        $stubs = self::generateStubs($code);
+
+        self::assertSame(1, substr_count($stubs, '@phpstan-return'), $stubs);
+        self::assertStringContainsString(
+            '@phpstan-return ?array{name: non-empty-string, type: non-empty-string}',
+            $stubs
+        );
+    }
+
+    /**
+     * Without an existing `@phpstan-return`, the visitor still synthesises one from
+     * a `@return` tag that uses array hash notation.
+     */
+    public function testPhpStanReturnIsStillGeneratedFromReturnHash(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        /**
+         * @return array|null {
+         *     @type string $name Name.
+         *     @type string $type Type.
+         * }
+         */
+        function wpstubs_test_connector_without_phpstan_return( string $id ): ?array {
+            return null;
+        }
+        PHP;
+
+        $stubs = self::generateStubs($code);
+
+        self::assertSame(1, substr_count($stubs, '@phpstan-return'), $stubs);
+        self::assertStringContainsString('name: string', $stubs);
+        self::assertStringContainsString('type: string', $stubs);
+    }
+}

--- a/wordpress-stubs.php
+++ b/wordpress-stubs.php
@@ -121526,23 +121526,6 @@ namespace {
      *         is_active: callable(): bool,
      *     }
      * }
-     * @phpstan-return null|array{
-     *   name: string,
-     *   description: string,
-     *   logo_url: string,
-     *   type: string,
-     *   authentication: array{
-     *     method: string,
-     *     credentials_url: string,
-     *     setting_name: string,
-     *     constant_name: string,
-     *     env_var_name: string,
-     *   },
-     *   plugin: array{
-     *     file: string,
-     *     is_active: callable,
-     *   },
-     * }
      */
     function wp_get_connector(string $id): ?array
     {
@@ -121601,23 +121584,6 @@ namespace {
      *         file?: non-empty-string,
      *         is_active: callable(): bool,
      *     }
-     * }>
-     * @phpstan-return array<int|string, array{
-     *   name: string,
-     *   description: string,
-     *   logo_url: string,
-     *   type: string,
-     *   authentication: array{
-     *     method: string,
-     *     credentials_url: string,
-     *     setting_name: string,
-     *     constant_name: string,
-     *     env_var_name: string,
-     *   },
-     *   plugin: array{
-     *     file: string,
-     *     is_active: callable,
-     *   },
      * }>
      */
     function wp_get_connectors(): array


### PR DESCRIPTION
WordPress core has started adding its own `@phpstan-return` tags now, for example on `wp_get_connector()`. The wordpress-stubs package shouldn't generate its own `@phpstan-return` tag if one already exists. This implements that change.