### PR TITLE
Remove unused submenu icon test

### DIFF
--- a/tests/data/return/block-core.php
+++ b/tests/data/return/block-core.php
@@ -10,7 +10,6 @@ assertType('int<0, max>', block_core_post_time_to_read_word_count(Faker::string(
 assertType('non-falsy-string', build_dropdown_script_block_core_categories(Faker::string()));
 
 // Submenu icon
-assertType('non-falsy-string', block_core_navigation_render_submenu_icon());
 assertType('non-falsy-string', block_core_shared_navigation_render_submenu_icon());
 
 // Render block


### PR DESCRIPTION
Removed assertion for block_core_navigation_render_submenu_icon.

@johnbillion Does it ring a bell for you?