### PR TITLE
Specify the cron array return type

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -45,6 +45,7 @@ return [
     '__return_empty_array' => ['array{}'],
     '__return_empty_string' => ["''"],
     '__return_zero' => ['0'],
+    '_get_cron_array' => ['array<int, array<string, array<string, array{schedule: string|false, args: array<mixed>, interval?: int<0, max>}>>>'],
     '_get_list_table' => ["(\$class_name is 'WP_Posts_List_Table'|'WP_Media_List_Table'|'WP_Terms_List_Table'|'WP_Users_List_Table'|'WP_Comments_List_Table'|'WP_Post_Comments_List_Table'|'WP_Links_List_Table'|'WP_Plugin_Install_List_Table'|'WP_Themes_List_Table'|'WP_Theme_Install_List_Table'|'WP_Plugins_List_Table'|'WP_Application_Passwords_List_Table'|'WP_MS_Sites_List_Table'|'WP_MS_Users_List_Table'|'WP_MS_Themes_List_Table'|'WP_Privacy_Data_Export_Requests_List_Table'|'WP_Privacy_Data_Removal_Requests_List_Table' ? new<T> : false)", '@phpstan-template T' => 'of string', 'class_name' => 'T', 'args' => 'array{screen?: string}'],
     '_load_remote_block_patterns' => [null, 'deprecated' => 'null'],
     'absint' => ['($maybeint is T&int<0, max> ? T : ($maybeint is int<min, -1> ? int<1, max> : ($maybeint is empty ? 0 : ($maybeint is numeric-string ? int<0, max> : ($maybeint is string ? 0 : ($maybeint is true|non-empty-array ? 1 : ($maybeint is bool ? 0|1 : int<0, max>)))))))', '@phpstan-template T' => 'of int', 'maybeint' => 'T|scalar|array|resource|null', '@phpstan-pure' => ''],

--- a/tests/data/return/get-cron-array.php
+++ b/tests/data/return/get-cron-array.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function PHPStan\Testing\assertType;
+use function _get_cron_array;
+
+assertType(
+    'array<int, array<string, array<string, array{schedule: string|false, args: array<mixed>, interval?: int<0, max>}>>>',
+    _get_cron_array()
+);

--- a/wordpress-stubs.php
+++ b/wordpress-stubs.php
@@ -122111,6 +122111,7 @@ namespace {
      * @access private
      *
      * @return array[] Array of cron events.
+     * @phpstan-return array<int, array<string, array<string, array{schedule: string|false, args: array<mixed>, interval?: int<0, max>}>>>
      */
     function _get_cron_array()
     {


### PR DESCRIPTION
## Summary

- add a PHPStan return-type override for `_get_cron_array()`
- regenerate the matching WordPress stub annotation
- add a focused type-inference regression test for the nested cron event shape

Fixes #269.

## Testing

- `php -d memory_limit=-1 vendor/bin/phpunit --filter 'get-cron-array\.php' --testdox`
- full PHPUnit suite: 1,442 tests, 1,612 assertions
- full PHPStan analysis in serial debug mode
- PHPCS
- stub generation and PHP syntax checks
- `git diff --check`
