### PR TITLE
WP_Comments_List_Table::floated_admin_avatar: narrow return type

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -364,6 +364,7 @@ return [
     'WP_Block_List::offsetGet' => ['\WP_Block|null', 'offset' => 'int'],
     'WP_Block_List::offsetSet' => ['void', 'offset' => 'int|null'],
     'WP_Block_List::offsetUnset' => ['void', 'offset' => 'int'],
+    'WP_Comments_List_Table::floated_admin_avatar' => ['non-falsy-string'],
     'WP_Object_Cache::delete' => [null, 'deprecated' => 'false'],
     'WP_Dependencies::$groups' => [null, '@phpstan-var' => 'array<string, int|false>'],
     'WP_Dependencies::get_etag' => ['non-falsy-string'],

--- a/tests/data/return/wp-comments-list-table.php
+++ b/tests/data/return/wp-comments-list-table.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use WP_Comments_List_Table;
+
+use function PHPStan\Testing\assertType;
+
+$commentsListTable = new WP_Comments_List_Table();
+
+assertType('non-falsy-string', $commentsListTable->floated_admin_avatar('', 0));
+assertType('non-falsy-string', $commentsListTable->floated_admin_avatar('name', 123));
+assertType('non-falsy-string', $commentsListTable->floated_admin_avatar(Faker::string(), Faker::int()));

--- a/wordpress-stubs.php
+++ b/wordpress-stubs.php
@@ -4481,6 +4481,7 @@ namespace {
          * @param string $name       Comment author name.
          * @param int    $comment_id Comment ID.
          * @return string Avatar with the user name.
+         * @phpstan-return non-falsy-string
          */
         public function floated_admin_avatar($name, $comment_id)
         {


### PR DESCRIPTION
`WP_Comments_List_Table::floated_admin_avatar()` returns `"$avatar $name"` (see [method reference](https://developer.wordpress.org/reference/classes/wp_comments_list_table/floated_admin_avatar/)) which is a non-falsy-string.