### PR TITLE
Remove obsolete `WP_Theme::get()` from the function map

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -410,7 +410,6 @@ return [
         '@phpstan-property-read string $theme_root' => '',
         '@phpstan-property-read string $theme_root_uri' => '',
     ],
-    'WP_Theme::get' => ["(\$header is 'Name'|'ThemeURI'|'Description'|'Author'|'AuthorURI'|'Version'|'Template'|'Status'|'Tags'|'TextDomain'|'DomainPath'|'RequiresWP'|'RequiresPHP'|'UpdateURI' ? (\$header is 'Tags' ? string[] : string) : false)"],
     'WP_Theme::offsetExists' => ['($offset is ThemeKey ? true : false)'],
     'WP_Theme::offsetGet' => ['($offset is ThemeKey ? mixed : null)'],
     'WP_Theme_JSON_Resolver::get_theme_data' => [null, 'deprecated' => 'array{}'],

--- a/tests/data/return/wp-theme.php
+++ b/tests/data/return/wp-theme.php
@@ -25,24 +25,6 @@ assertType('string', $theme->theme_root);
 assertType('string', $theme->theme_root_uri);
 assertType('*ERROR*', $theme->unknown_property);
 
-// WP_Theme::get()
-assertType('string', $theme->get('Name'));
-assertType('string', $theme->get('ThemeURI'));
-assertType('string', $theme->get('Description'));
-assertType('string', $theme->get('Author'));
-assertType('string', $theme->get('AuthorURI'));
-assertType('string', $theme->get('Version'));
-assertType('string', $theme->get('Template'));
-assertType('string', $theme->get('Status'));
-assertType('array<string>', $theme->get('Tags'));
-assertType('string', $theme->get('TextDomain'));
-assertType('string', $theme->get('DomainPath'));
-assertType('string', $theme->get('RequiresWP'));
-assertType('string', $theme->get('RequiresPHP'));
-assertType('string', $theme->get('UpdateURI'));
-assertType('false', $theme->get('NoThemeHeader'));
-assertType('array<string>|string|false', $theme->get(Faker::string()));
-
 // WP_Theme::offsetExists()
 assertType('false', $theme->offsetExists('NoThemeKey'));
 assertType('true', $theme->offsetExists('Name'));

--- a/wordpress-stubs.php
+++ b/wordpress-stubs.php
@@ -57946,7 +57946,6 @@ namespace {
          *             ? string|false
          *             : false )
          * )
-         * @phpstan-return ($header is 'Name'|'ThemeURI'|'Description'|'Author'|'AuthorURI'|'Version'|'Template'|'Status'|'Tags'|'TextDomain'|'DomainPath'|'RequiresWP'|'RequiresPHP'|'UpdateURI' ? ($header is 'Tags' ? string[] : string) : false)
          */
         public function get($header)
         {


### PR DESCRIPTION
A corresponding `phpstan-return` tag has been added in WP 7.0. See [wp-includes/class-wp-theme.php](https://github.com/WordPress/WordPress/blob/b16cd68ea199838d8f9daf0ff7e3f35042ba0ad0/wp-includes/class-wp-theme.php#L870-L878).