### PR TITLE
add concurrency to integrate workflow

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -8,6 +8,10 @@ on:
     branches:
     - "master"
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 permissions:
   contents: "read"
 


### PR DESCRIPTION
Adds concurrency control to the integrate workflow. When a new commit is pushed, any in-progress run for an earlier commit is cancelled, avoiding unnecessary work on outdated code.