### PR TITLE
path_join: narrow return type

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -180,6 +180,7 @@ return [
     'newblog_notify_siteadmin' => [null, 'deprecated' => "''"],
     'next_posts' => ['($display is true ? void : string)'],
     'paginate_links' => ["(\$args is array{total: int<min, 1>}&array ? void : (\$args is array{type: 'array'}&array ? list<string> : string))"],
+    'path_join' => ['non-falsy-string'],
     'post_type_archive_title' => ['($display is true ? void : string|void)'],
     'prep_atom_text_construct' => ["array{'html'|'text'|'xhtml', string}"],
     'previous_posts' => ['($display is true ? void : string)'],

--- a/tests/data/return/path-join.php
+++ b/tests/data/return/path-join.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function path_join;
+use function PHPStan\Testing\assertType;
+
+assertType('non-falsy-string', path_join('', ''));
+assertType('non-falsy-string', path_join('base', 'path'));
+assertType('non-falsy-string', path_join(Faker::string(), Faker::string()));

--- a/wordpress-stubs.php
+++ b/wordpress-stubs.php
@@ -130066,6 +130066,7 @@ namespace {
      * @param string $base Base path.
      * @param string $path Path relative to $base.
      * @return string The path with the base or absolute path.
+     * @phpstan-return non-falsy-string
      */
     function path_join($base, $path)
     {


### PR DESCRIPTION
[path_join()](https://developer.wordpress.org/reference/functions/path_join/):
```php
/**
 * @param string $base Base path.
 * @param string $path Path relative to $base.
 * @return string The path with the base or absolute path.
 */
function path_join( $base, $path ) {
	if ( path_is_absolute( $path ) ) {
		return $path;
	}

	return rtrim( $base, '/' ) . '/' . $path;
}
```

Neither `''` nor `'0'` is an [absolute path](https://developer.wordpress.org/reference/functions/path_is_absolute/). Therefore, `path_join()` returns a `non-falsy-string`.