### PR TITLE
block_core_breadcrumbs_create_item: add cond. return type

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -73,6 +73,7 @@ return [
     'apply_filters_ref_array' => [null, 'hook_name' => 'non-empty-string'],
     'apply_filters_deprecated' => [null, 'hook_name' => 'non-empty-string'],
     'backslashit' => [null, '@phpstan-pure' => ''],
+    'block_core_breadcrumbs_create_item' => ['($is_paged is true ? array{label: T, url: string} : array{label: T})', '@phpstan-template T' => 'of string', 'text' => 'T'],
     'block_core_home_link_build_css_colors' => ['array{css_classes: list<string>, inline_styles: string}'],
     'block_core_home_link_build_css_font_sizes' => ['array{css_classes: list<string>, inline_styles: string}'],
     'block_core_navigation_build_css_colors' => ['array{css_classes: list<string>, inline_styles: string, overlay_css_classes: list<string>, overlay_inline_styles: string}'],

--- a/tests/data/return/block-core.php
+++ b/tests/data/return/block-core.php
@@ -34,3 +34,9 @@ assertType('array{css_classes: list<string>, inline_styles: string}', block_core
 assertType('array{css_classes: list<string>, inline_styles: string}', block_core_navigation_submenu_build_css_font_sizes(Faker::array()));
 assertType('array{css_classes: list<string>, inline_styles: string, overlay_css_classes: list<string>, overlay_inline_styles: string}', block_core_page_list_build_css_colors(Faker::array(), Faker::array()));
 assertType('array{css_classes: list<string>, inline_styles: string}', block_core_page_list_build_css_font_sizes(Faker::array()));
+
+// Breadcrumbs
+assertType('array{label: string, url?: string}', block_core_breadcrumbs_create_item(Faker::string(), Faker::bool()));
+assertType("array{label: 'foo', url?: string}", block_core_breadcrumbs_create_item('foo', Faker::bool()));
+assertType('array{label: string}', block_core_breadcrumbs_create_item(Faker::string(), false));
+assertType('array{label: string, url: string}', block_core_breadcrumbs_create_item(Faker::string(), true));

--- a/wordpress-stubs.php
+++ b/wordpress-stubs.php
@@ -113436,6 +113436,9 @@ namespace {
      * @param bool   $is_paged   Whether we're on a paginated view.
      *
      * @return array The breadcrumb item data.
+     * @phpstan-template T of string
+     * @phpstan-param T $text
+     * @phpstan-return ($is_paged is true ? array{label: T, url: string} : array{label: T})
      */
     function block_core_breadcrumbs_create_item($text, $is_paged = \false)
     {


### PR DESCRIPTION
[block_core_breadcrumbs_create_item()](https://github.com/WordPress/WordPress/blob/663b347ab84d196d075e518cd824f0240425a0a5/wp-includes/blocks/breadcrumbs.php#L256-L275):

```php
 * @param string $text       The text content.
 * @param bool   $is_paged   Whether we're on a paginated view.
 *
 * @return array The breadcrumb item data.
 */
function block_core_breadcrumbs_create_item( $text, $is_paged = false ) {
	$item = array( 'label' => $text );
	if ( $is_paged ) {
		$item['url'] = get_pagenum_link( 1 );
	}
	return $item;
}
```

`block_core_breadcrumbs_create_item()` returns an array with `$text` as is keyed by `'label'` (template `T`). If `$is_paged` is truthy a key `'url'` with `string` value is added (conditional return type).

oracle-inspired