### PR TITLE
add_cssclass: add conditional return type

### DIFF
--- a/functionMap.php
+++ b/functionMap.php
@@ -51,6 +51,7 @@ return [
     'absint' => ['($maybeint is T&int<0, max> ? T : ($maybeint is int<min, -1> ? int<1, max> : ($maybeint is empty ? 0 : ($maybeint is numeric-string ? int<0, max> : ($maybeint is string ? 0 : ($maybeint is true|non-empty-array ? 1 : ($maybeint is bool ? 0|1 : int<0, max>)))))))', '@phpstan-template T' => 'of int', 'maybeint' => 'T|scalar|array|resource|null', '@phpstan-pure' => ''],
     '_wp_post_revision_fields' => [null, 'deprecated' => 'false'],
     'add_comments_page' => [null, 'callback' => "''|callable"],
+    'add_cssclass' => ['($classes is empty ? T : non-empty-string)', '@phpstan-template T' => 'of string', 'class_to_add' => 'T', '@phpstan-pure' => ''],
     'add_dashboard_page' => [null, 'callback' => "''|callable"],
     'add_feed' => ['non-falsy-string', 'callback' => 'callable(bool, string): void'],
     'add_link' => ['int<0, max>'],

--- a/tests/data/pure/add-cssclass.php
+++ b/tests/data/pure/add-cssclass.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function add_cssclass;
+use function PHPStan\Testing\assertType;
+
+$classes = Faker::string();
+$classToAdd = Faker::string();
+
+assertType('string', add_cssclass($classes, $classToAdd));
+
+if (add_cssclass($classes, $classToAdd) === 'foo') {
+    assertType("'foo'", add_cssclass($classes, $classToAdd));
+}
+
+if (add_cssclass($classes, $classToAdd) === 'bar') {
+    assertType("'bar'", add_cssclass($classes, $classToAdd));
+}

--- a/tests/data/return/add-cssclass.php
+++ b/tests/data/return/add-cssclass.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpStubs\WordPress\Core\Tests;
+
+use function add_cssclass;
+use function PHPStan\Testing\assertType;
+
+assertType("''", add_cssclass('', ''));
+assertType("'foo'", add_cssclass('foo', ''));
+assertType('non-empty-string', add_cssclass('', 'foo'));
+assertType('non-empty-string', add_cssclass('foo', 'bar'));
+assertType('string', add_cssclass(Faker::string(), Faker::string()));
+assertType('non-falsy-string', add_cssclass(Faker::nonFalsyString(), ''));
+assertType('non-empty-string', add_cssclass(Faker::nonFalsyString(), Faker::nonFalsyString()));
+assertType('non-empty-string', add_cssclass(Faker::nonFalsyString(), Faker::string()));

--- a/wordpress-stubs.php
+++ b/wordpress-stubs.php
@@ -101596,6 +101596,10 @@ namespace {
      * @param string $class_to_add The CSS class to add.
      * @param string $classes      The string to add the CSS class to.
      * @return string The string with the CSS class added.
+     * @phpstan-template T of string
+     * @phpstan-param T $class_to_add
+     * @phpstan-pure
+     * @phpstan-return ($classes is empty ? T : non-empty-string)
      */
     function add_cssclass($class_to_add, $classes)
     {


### PR DESCRIPTION
[add_cssclass()](https://developer.wordpress.org/reference/functions/add_cssclass/):

```php
 * @param string $class_to_add The CSS class to add.
 * @param string $classes      The string to add the CSS class to.
 * @return string The string with the CSS class added.
 */
function add_cssclass( $class_to_add, $classes ) {
	if ( empty( $classes ) ) {
		return $class_to_add;
	}

	return $classes . ' ' . $class_to_add;
}
```

Whenever `$classes` is an empty string `$class_to_add` is returned as is (template `T`). If `$classes` is not empty, `$class_to_add` is appended and returned. We therefore know, it's a non-empty-string. Further refinement would required a more complex conditional return type. The returned type depends on `$classes` (conditional type).

oracle-inspired